### PR TITLE
Test logs UI crash

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,7 @@ jobs:
   build:
     name: Build and Archive
     runs-on: macos-11
+    timeout-minutes: 3
     permissions:
       issues: write 
       pull-requests: write
@@ -43,7 +44,7 @@ jobs:
           ${{ runner.os }}-build-
           ${{ runner.os }}-
     - name: Build
-      run: make build archive | xcpretty
+      run: make build archive | xcpretty && exit ${PIPESTATUS[0]}
     - name: Compress app for storage
       run: zip -r app.zip build/mac/Pareto\ Security.app
     - name: Upload App to Artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ jobs:
   release:
     name: Build and Archive
     runs-on: macos-11
+    timeout-minutes: 3
     permissions:
       deployments: write
     steps:
@@ -34,7 +35,7 @@ jobs:
           ${{ runner.os }}-build-
           ${{ runner.os }}-
     - name: Build
-      run: make build archive | xcpretty
+      run: make build archive | xcpretty && exit ${PIPESTATUS[0]}
     - name: Compress app for storage
       run: zip -r app.zip build/mac/Pareto\ Security.app
     - name: Upload App to Artifacts

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,7 @@ jobs:
   swift:
     name: Lint
     runs-on: macos-11
+    timeout-minutes: 3
     steps:
     - uses: maxim-lobanov/setup-xcode@v1
       with:
@@ -45,6 +46,6 @@ jobs:
           ${{ runner.os }}-build-
           ${{ runner.os }}-
     - name: Tests
-      run: make test | xcpretty
+      run: make test | xcpretty -tc && exit ${PIPESTATUS[0]}
     - name: Update coverage
       run: bash <(curl -s https://codecov.io/bash)

--- a/Pareto/AppInfo.swift
+++ b/Pareto/AppInfo.swift
@@ -48,6 +48,13 @@ enum AppInfo {
 
     static let logEntries = { () -> [String] in
         var logs = [String]()
+        logs.append("State:")
+        for (k, v) in UserDefaults.standard.dictionaryRepresentation().sorted(by: { $0.key < $1.key }) {
+            if k.starts(with: "ParetoCheck-") {
+                logs.append("\(k)=\(v)")
+            }
+        }
+        logs.append("\nLogs:")
         do {
             if #available(macOS 12.0, *) {
                 let logStore = try OSLogStore(scope: .currentProcessIdentifier)

--- a/Pareto/Info.plist
+++ b/Pareto/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>1007</string>
+	<string>1010</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/Pareto/ParetoCheck.swift
+++ b/Pareto/ParetoCheck.swift
@@ -17,27 +17,27 @@ class ParetoCheck: ObservableObject {
     private(set) var canRunInSandbox = true
 
     var EnabledKey: String {
-        UUID + "-Enabled"
+        "ParetoCheck-" + UUID + "-Enabled"
     }
 
     var SnoozeKey: String {
-        UUID + "-Snooze"
+        "ParetoCheck-" + UUID + "-Snooze"
     }
 
     var PassesKey: String {
-        UUID + "-Passes"
+        "ParetoCheck-" + UUID + "-Passes"
     }
 
     var TimestampKey: String {
-        UUID + "-TS"
+        "ParetoCheck-" + UUID + "-TS"
     }
 
     init() {
         UserDefaults.standard.register(defaults: [
-            UUID + "-Enabled": true,
-            UUID + "-Snooze": 0,
-            UUID + "-Passes": false,
-            UUID + "-TS": 0
+            "ParetoCheck-" + UUID + "-Enabled": true,
+            "ParetoCheck-" + UUID + "-Snooze": 0,
+            "ParetoCheck-" + UUID + "-Passes": false,
+            "ParetoCheck-" + UUID + "-TS": 0
         ])
     }
 

--- a/ParetoSecurityTests/CheckIntegrationTest.swift
+++ b/ParetoSecurityTests/CheckIntegrationTest.swift
@@ -22,10 +22,10 @@ class CheckIntegrationTest: XCTestCase {
         XCTAssertEqual(check.Title, "Unit test mock")
 
         // Ensure keys are not changed without migration
-        XCTAssertEqual(check.PassesKey, "aaaaaaaa-bbbb-cccc-dddd-abcdef123456-Passes")
-        XCTAssertEqual(check.SnoozeKey, "aaaaaaaa-bbbb-cccc-dddd-abcdef123456-Snooze")
-        XCTAssertEqual(check.EnabledKey, "aaaaaaaa-bbbb-cccc-dddd-abcdef123456-Enabled")
-        XCTAssertEqual(check.TimestampKey, "aaaaaaaa-bbbb-cccc-dddd-abcdef123456-TS")
+        XCTAssertEqual(check.PassesKey, "ParetoCheck-aaaaaaaa-bbbb-cccc-dddd-abcdef123456-Passes")
+        XCTAssertEqual(check.SnoozeKey, "ParetoCheck-aaaaaaaa-bbbb-cccc-dddd-abcdef123456-Snooze")
+        XCTAssertEqual(check.EnabledKey, "ParetoCheck-aaaaaaaa-bbbb-cccc-dddd-abcdef123456-Enabled")
+        XCTAssertEqual(check.TimestampKey, "ParetoCheck-aaaaaaaa-bbbb-cccc-dddd-abcdef123456-TS")
     }
 
     func testCheckPasses() throws {


### PR DESCRIPTION
Using computed property in SharedPrefrences register prevents tests to pass on CI. To get around that use the less nicer static strings.