### PR TITLE
Use config check for cups

### DIFF
--- a/Pareto Security.xcodeproj/project.pbxproj
+++ b/Pareto Security.xcodeproj/project.pbxproj
@@ -15,7 +15,6 @@
 		4F14487726D8EB2E00A5BA34 /* Version in Frameworks */ = {isa = PBXBuildFile; productRef = 4F14487626D8EB2E00A5BA34 /* Version */; };
 		4F14487A26D8EB7A00A5BA34 /* Path in Frameworks */ = {isa = PBXBuildFile; productRef = 4F14487926D8EB7A00A5BA34 /* Path */; };
 		4F14487C26D8EDB000A5BA34 /* Bundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F14487B26D8EDB000A5BA34 /* Bundle.swift */; };
-		4F35395326E8A6EA008F5DD3 /* LoaderUI in Frameworks */ = {isa = PBXBuildFile; productRef = 4F35395226E8A6EA008F5DD3 /* LoaderUI */; };
 		4F35395526E8AD4C008F5DD3 /* RemoteManagment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F35395426E8AD4B008F5DD3 /* RemoteManagment.swift */; };
 		4F35395726E8AE02008F5DD3 /* RemoteLogin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F35395626E8AE02008F5DD3 /* RemoteLogin.swift */; };
 		4F3EF24326CA859500841375 /* Claim.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F3EF24226CA859500841375 /* Claim.swift */; };
@@ -133,7 +132,6 @@
 				4F14487726D8EB2E00A5BA34 /* Version in Frameworks */,
 				4F14487A26D8EB7A00A5BA34 /* Path in Frameworks */,
 				4F6A0E1326CE608C003B00A3 /* Defaults in Frameworks */,
-				4F35395326E8A6EA008F5DD3 /* LoaderUI in Frameworks */,
 				4F103012269F1C65008C1E86 /* LaunchAtLogin in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -337,7 +335,6 @@
 				4F6A0E1226CE608C003B00A3 /* Defaults */,
 				4F14487626D8EB2E00A5BA34 /* Version */,
 				4F14487926D8EB7A00A5BA34 /* Path */,
-				4F35395226E8A6EA008F5DD3 /* LoaderUI */,
 			);
 			productName = Pareto;
 			productReference = 4FEBA2EE269CD48F009B2469 /* Pareto Security.app */;
@@ -380,7 +377,6 @@
 				4F6A0E1126CE608C003B00A3 /* XCRemoteSwiftPackageReference "Defaults" */,
 				4F14487526D8EB2E00A5BA34 /* XCRemoteSwiftPackageReference "Version" */,
 				4F14487826D8EB7A00A5BA34 /* XCRemoteSwiftPackageReference "Path.swift" */,
-				4F35395126E8A6EA008F5DD3 /* XCRemoteSwiftPackageReference "LoaderUI" */,
 			);
 			productRefGroup = 4FEBA2EF269CD48F009B2469 /* Products */;
 			projectDirPath = "";
@@ -874,14 +870,6 @@
 				minimumVersion = 1.0.0;
 			};
 		};
-		4F35395126E8A6EA008F5DD3 /* XCRemoteSwiftPackageReference "LoaderUI" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/ParetoSecurity/LoaderUI";
-			requirement = {
-				branch = master;
-				kind = branch;
-			};
-		};
 		4F6A0E1126CE608C003B00A3 /* XCRemoteSwiftPackageReference "Defaults" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/sindresorhus/Defaults";
@@ -915,11 +903,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 4F14487826D8EB7A00A5BA34 /* XCRemoteSwiftPackageReference "Path.swift" */;
 			productName = Path;
-		};
-		4F35395226E8A6EA008F5DD3 /* LoaderUI */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 4F35395126E8A6EA008F5DD3 /* XCRemoteSwiftPackageReference "LoaderUI" */;
-			productName = LoaderUI;
 		};
 		4F6A0E1226CE608C003B00A3 /* Defaults */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Pareto Security.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Pareto Security.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -20,15 +20,6 @@
         }
       },
       {
-        "package": "LoaderUI",
-        "repositoryURL": "https://github.com/ParetoSecurity/LoaderUI",
-        "state": {
-          "branch": "master",
-          "revision": "4073a102681be36724734e6c45045f9eb777dee5",
-          "version": null
-        }
-      },
-      {
         "package": "Path.swift",
         "repositoryURL": "https://github.com/mxcl/Path.swift.git",
         "state": {

--- a/Pareto/Checks/PrinterSharingCheck.swift
+++ b/Pareto/Checks/PrinterSharingCheck.swift
@@ -19,6 +19,10 @@ class PrinterSharingCheck: ParetoCheck {
     }
 
     override func checkPasses() -> Bool {
-        return isNotListening(withPort: 631)
+        let output = runCMD(app: "/usr/sbin/cupsctl", args: [])
+        let settings = ["_share_printers=0", "_remote_admin=0", "_remote_any=0"]
+        return settings.allSatisfy {
+            output.contains($0)
+        }
     }
 }

--- a/Pareto/Info.plist
+++ b/Pareto/Info.plist
@@ -26,7 +26,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>1716</string>
+	<string>1733</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/Pareto/Views/SettingsView.swift
+++ b/Pareto/Views/SettingsView.swift
@@ -7,7 +7,6 @@
 import AppKit
 import Defaults
 import LaunchAtLogin
-import LoaderUI
 import SwiftUI
 
 struct GeneralSettingsView: View {
@@ -114,9 +113,8 @@ struct AboutSettingsView: View {
                     HStack {
                         Text(status.rawValue)
                         if self.isLoading {
-                            SemiCircleSpin().frame(width: 15, height: 15, alignment: .center)
-                        } else {
-                            SemiCircleSpin().frame(width: 15, height: 15, alignment: .center).hidden()
+                            ProgressView().frame( width: 5.0, height: 5.0)
+                                .scaleEffect(x: 0.5, y: 0.5, anchor: .center)
                         }
                     }
                 }

--- a/Pareto/Views/SettingsView.swift
+++ b/Pareto/Views/SettingsView.swift
@@ -113,7 +113,7 @@ struct AboutSettingsView: View {
                     HStack {
                         Text(status.rawValue)
                         if self.isLoading {
-                            ProgressView().frame( width: 5.0, height: 5.0)
+                            ProgressView().frame(width: 5.0, height: 5.0)
                                 .scaleEffect(x: 0.5, y: 0.5, anchor: .center)
                         }
                     }


### PR DESCRIPTION
Printers sharing check would report that cups is on because cupsd daemon would run periodically in background and expose web server on port 631. Use config check to verify the configuration and ignore the server running.