### PR TITLE
More consistent naming of SSH key password check

### DIFF
--- a/Pareto/Checks/Access Security/SSHKeys.swift
+++ b/Pareto/Checks/Access Security/SSHKeys.swift
@@ -17,14 +17,14 @@ class SSHKeysCheck: ParetoCheck {
     }
 
     override var TitleON: String {
-        "All SSH keys require a password"
+        "SSH keys require a password"
     }
 
     override var TitleOFF: String {
         if sshKey.isEmpty {
-            return "One of SSH keys is missing password"
+            return "SSH key is missing a password"
         }
-        return "The \(sshKey) SSH key is missing password"
+        return "SSH key \(sshKey) is missing a password"
     }
 
     func itExists(_ path: String) -> Bool {


### PR DESCRIPTION
So that the check does not jump around in the app UI.

Refs https://github.com/niteoweb/pareto/issues/204