### PR TITLE
feat: remove ignored checks from team settings

### DIFF
--- a/Pareto/AppHandlers.swift
+++ b/Pareto/AppHandlers.swift
@@ -285,7 +285,7 @@ class AppHandlers: NSObject, NetworkHandlerObserver {
     @objc func docs() {
         NSWorkspace.shared.open(AppInfo.docsURL())
     }
-    
+
     @objc func teamsDashboard() {
         NSWorkspace.shared.open(AppInfo.teamsURL())
     }
@@ -341,7 +341,7 @@ class AppHandlers: NSObject, NetworkHandlerObserver {
             alert.runModal()
         }
 
-        
+
         if let data = try? AppInfo.logEntries().joined(separator: "\n") {
             if !data.isEmpty {
                 NSPasteboard.general.clearContents()
@@ -354,7 +354,7 @@ class AppHandlers: NSObject, NetworkHandlerObserver {
                 return
             }
         }
-        
+
         let alert = NSAlert()
         alert.messageText = "Thre are no logs to copy. App logs are only available after the application has been running for a while."
         alert.alertStyle = NSAlert.Style.informational
@@ -411,7 +411,6 @@ class AppHandlers: NSObject, NetworkHandlerObserver {
                     Team.link(withDevice: ReportingDevice.current()).response { response in
                         switch response.result {
                         case .success:
-                            Defaults[.appliedIgnoredChecks] = false
                             DispatchQueue.main.async {
                                 let alert = NSAlert()
                                 alert.messageText = "Pareto Security is activated and linked."

--- a/Pareto/Defaults.swift
+++ b/Pareto/Defaults.swift
@@ -33,8 +33,6 @@ extension Defaults.Keys {
     static let machineUUID = Key<String>("machineUUID", default: AppInfo.getSystemUUID() ?? UUID().uuidString, suite: extensionDefaults)
     static let sendHWInfo = Key<Bool>("sendHWInfo", default: false, suite: extensionDefaults)
     static let lastHWAsk = Key<Int>("lastHWAsk", default: 0, suite: extensionDefaults)
-    static let appliedIgnoredChecks = Key<Bool>("appliedIgnoredChecksv1", default: false, suite: extensionDefaults)
-    static let appliedIgnoredChecksIDs = Key<[String]>("appliedIgnoredChecksv4", default: [], suite: extensionDefaults)
     // License
     static let license = Key<String>("license", default: "", suite: extensionDefaults)
     static let reportingRole = Key<ReportingRoles>("reportingRole", default: .free, suite: extensionDefaults)

--- a/Pareto/Info.plist
+++ b/Pareto/Info.plist
@@ -26,7 +26,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>5597</string>
+	<string>5601</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/Pareto/ParetoApp.swift
+++ b/Pareto/ParetoApp.swift
@@ -140,7 +140,6 @@ class AppDelegate: AppHandlers, NSApplicationDelegate {
                 Team.link(withDevice: ReportingDevice.current()).response { response in
                     switch response.result {
                     case .success:
-                        Defaults[.appliedIgnoredChecks] = false
                         print("Team ticket is linked")
                         Defaults[.lastCheck] = 1
                         exit(0)

--- a/Pareto/StatusBar/StatusBarController.swift
+++ b/Pareto/StatusBar/StatusBarController.swift
@@ -141,7 +141,6 @@ class StatusBarController: NSObject, NSMenuDelegate {
         if !Defaults[.teamID].isEmpty {
             let lock = DispatchSemaphore(value: 0)
             AppInfo.TeamSettings.update {
-                AppInfo.TeamSettings.updateIgnored()
                 os_log("Updated teams settings")
                 lock.signal()
             }
@@ -302,7 +301,7 @@ class StatusBarController: NSObject, NSMenuDelegate {
         let docsItem = NSMenuItem(title: "Documentation", action: #selector(AppDelegate.docs), keyEquivalent: "d")
         docsItem.target = NSApp.delegate
         statusItemMenu.addItem(docsItem)
-        
+
         let reportItem = NSMenuItem(title: "Contact Support", action: #selector(AppDelegate.reportBug), keyEquivalent: "b")
         reportItem.target = NSApp.delegate
         statusItemMenu.addItem(reportItem)

--- a/ParetoSecurityTests/TeamsTest.swift
+++ b/ParetoSecurityTests/TeamsTest.swift
@@ -21,7 +21,6 @@ class TeamsTest: XCTestCase {
     func testLink() throws {
         Defaults[.teamID] = "fd4e6814-440c-46d2-b240-4e0d2f786fbc"
         Defaults[.teamAPI] = "http://localhost"
-        Defaults[.appliedIgnoredChecks] = false
 
         let device = ReportingDevice(
             machineUUID: "5d486371-7841-4e4d-95c4-78c71cdaa44c",
@@ -49,7 +48,6 @@ class TeamsTest: XCTestCase {
 
         Team.settings { settings in
             XCTAssertEqual(settings?.enforcedList, [])
-            XCTAssertEqual(settings?.ignoredList, [])
         }
     }
 }


### PR DESCRIPTION
Simplify checks settings for teams to only have `required` and `optional` check level options.

Ref: https://github.com/teamniteo/pareto-dash/pull/327