### PR TITLE
Add error handling and logging improvements across various app checks

### DIFF
--- a/Pareto/Checks/AppCheck.swift
+++ b/Pareto/Checks/AppCheck.swift
@@ -94,6 +94,7 @@ class AppCheck: ParetoCheck, AppCheckProtocol {
                 } else {
                     os_log("%{public}s failed: %{public}s", self.appBundle, response.error.debugDescription)
                     completion("0.0.0")
+                    self.hasError = true
                     return
                 }
             })

--- a/Pareto/Checks/Application Updates/1Password8.swift
+++ b/Pareto/Checks/Application Updates/1Password8.swift
@@ -30,6 +30,7 @@ class App1Password8Check: AppCheck {
                 completion(result.last?.groups.first?.value ?? "0.0.0")
             } else {
                 os_log("%{public}s failed: %{public}s", self.appBundle, response.error.debugDescription)
+                self.hasError = true
                 completion("0.0.0")
             }
 

--- a/Pareto/Checks/Application Updates/AdobeReader.swift
+++ b/Pareto/Checks/Application Updates/AdobeReader.swift
@@ -35,6 +35,7 @@ class AdobeReaderCheck: AppCheck {
                 completion(result?.groups.first?.value ?? "0.0.0")
             } else {
                 os_log("%{public}s failed: %{public}s", self.appBundle, response.error.debugDescription)
+                self.hasError = true
                 completion("0.0.0")
             }
 

--- a/Pareto/Checks/Application Updates/Docker.swift
+++ b/Pareto/Checks/Application Updates/Docker.swift
@@ -33,6 +33,7 @@ class AppDockerCheck: AppCheck {
                 completion(result?.groups.first?.value ?? "0.0.0")
             } else {
                 os_log("%{public}s failed: %{public}s", self.appBundle, response.error.debugDescription)
+                self.hasError = true
                 completion("0.0.0")
             }
 

--- a/Pareto/Checks/Application Updates/MicrosoftTeams.swift
+++ b/Pareto/Checks/Application Updates/MicrosoftTeams.swift
@@ -55,6 +55,7 @@ class AppMicrosoftTeamsCheck: AppCheck {
                 completion(v ?? "0.0.0")
             } else {
                 os_log("%{public}s failed: %{public}s", self.appBundle, response.error.debugDescription)
+                self.hasError = true
                 completion("0.0.0")
             }
         })

--- a/Pareto/Checks/Application Updates/ParetoUpdated.swift
+++ b/Pareto/Checks/Application Updates/ParetoUpdated.swift
@@ -86,7 +86,7 @@ class ParetoUpdated: ParetoCheck {
                         sortedReleases = sortedReleases.filter { !$0.prerelease }
                     }
 
-                    // Include releases with publised date odler than 10 days
+                    // Include releases with published date older than 10 days
                     let tenDaysAgo = Date().addingTimeInterval(-10 * 24 * 60 * 60)
                     let dateFormatter = ISO8601DateFormatter()
                     // dateFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]

--- a/Pareto/Checks/Claim.swift
+++ b/Pareto/Checks/Claim.swift
@@ -34,6 +34,7 @@ class Claim: Hashable {
     }
 
     var checksPassed: Bool { checks.allSatisfy { $0.isRunnable ? $0.checkPassed : true } }
+    var checksNoError: Bool { checks.allSatisfy { $0.isRunnable ? $0.hasError : true } }
 
     func addSubmenu(withTitle: String, action: Selector?) -> NSMenuItem {
         let item = NSMenuItem(title: withTitle, action: action, keyEquivalent: "")
@@ -50,7 +51,7 @@ class Claim: Hashable {
                 if Defaults[.snoozeTime] > 0 {
                     item.image = NSImage.SF(name: "shield.fill").tint(color: .systemGray)
                 } else {
-                    if checksPassed {
+                    if checksPassed && checksNoError {
                         item.image = NSImage.SF(name: "checkmark.circle.fill").tint(color: Defaults.OKColor())
                     } else {
                         item.image = NSImage.SF(name: "xmark.diamond.fill").tint(color: Defaults.FailColor())

--- a/Pareto/Checks/Claim.swift
+++ b/Pareto/Checks/Claim.swift
@@ -34,7 +34,7 @@ class Claim: Hashable {
     }
 
     var checksPassed: Bool { checks.allSatisfy { $0.isRunnable ? $0.checkPassed : true } }
-    var checksNoError: Bool { checks.allSatisfy { $0.isRunnable ? $0.hasError : true } }
+    var checksNoError: Bool { checks.allSatisfy { $0.isRunnable ? !$0.hasError : true } }
 
     func addSubmenu(withTitle: String, action: Selector?) -> NSMenuItem {
         let item = NSMenuItem(title: withTitle, action: action, keyEquivalent: "")

--- a/Pareto/Checks/Firefox.swift
+++ b/Pareto/Checks/Firefox.swift
@@ -49,6 +49,7 @@ class AppFirefoxCheck: AppCheck {
                 completion(version)
             } else {
                 os_log("%{public}s failed: %{public}s", self.appBundle, response.error.debugDescription)
+                self.hasError = true
                 completion("0.0.0")
             }
         }

--- a/Pareto/Checks/GoogleChrome.swift
+++ b/Pareto/Checks/GoogleChrome.swift
@@ -60,6 +60,7 @@ class AppGoogleChromeCheck: AppCheck {
                 completion("\(v[0]).\(v[1]).\(v[2])")
             } else {
                 os_log("%{public}s failed: %{public}s", self.appBundle, response.error.debugDescription)
+                self.hasError = true
                 completion("0.0.0")
             }
         })

--- a/Pareto/Checks/LibreOffice.swift
+++ b/Pareto/Checks/LibreOffice.swift
@@ -44,6 +44,7 @@ class AppLibreOfficeCheck: AppCheck {
                 completion(versions)
             } else {
                 os_log("%{public}s failed: %{public}s", self.appBundle, response.error.debugDescription)
+                self.hasError = true
                 completion(["0.0.0"])
             }
         })

--- a/Pareto/Checks/LuLu.swift
+++ b/Pareto/Checks/LuLu.swift
@@ -38,6 +38,7 @@ class AppLuLuCheck: AppCheck {
                 completion(version)
             } else {
                 os_log("%{public}s failed: %{public}s", self.appBundle, response.error.debugDescription)
+                self.hasError = true
                 completion("0.0.0")
             }
 

--- a/Pareto/Checks/ParetoCheck.swift
+++ b/Pareto/Checks/ParetoCheck.swift
@@ -26,6 +26,9 @@ class ParetoCheck: Hashable, ObservableObject, Identifiable {
     private(set) var TitleON = "TitleON"
     private(set) var TitleOFF = "TitleOFF"
 
+    // Indicate check has errored
+    public var hasError = false
+
     // Add these properties to your ParetoCheck class:
     private var cachedIsRunnableValue: Bool?
     private var cachedIsRunnableTimestamp: Date?
@@ -140,10 +143,14 @@ class ParetoCheck: Hashable, ObservableObject, Identifiable {
             if Defaults[.snoozeTime] > 0 {
                 item.image = NSImage.SF(name: "seal.fill").tint(color: .systemGray)
             } else {
-                if checkPassed {
-                    item.image = NSImage.SF(name: "checkmark").tint(color: Defaults.OKColor())
+                if hasError {
+                    item.image = NSImage.SF(name: "questionmark").tint(color: Defaults.FailColor())
                 } else {
-                    item.image = NSImage.SF(name: "xmark").tint(color: Defaults.FailColor())
+                    if checkPassed {
+                        item.image = NSImage.SF(name: "checkmark").tint(color: Defaults.OKColor())
+                    } else {
+                        item.image = NSImage.SF(name: "xmark").tint(color: Defaults.FailColor())
+                    }
                 }
             }
         } else {
@@ -198,6 +205,7 @@ class ParetoCheck: Hashable, ObservableObject, Identifiable {
         }
 
         os_log("Running check for %{public}s - %{public}s", log: Log.app, UUID, Title)
+        hasError = false
         checkPassed = checkPasses()
         checkTimestamp = Int(Date().currentTimeMs())
 

--- a/Pareto/Checks/Signal.swift
+++ b/Pareto/Checks/Signal.swift
@@ -38,6 +38,7 @@ class AppSignalCheck: AppCheck {
                 completion(version)
             } else {
                 os_log("%{public}s failed: %{public}s", self.appBundle, response.error.debugDescription)
+                self.hasError = true
                 completion("0.0.0")
             }
 

--- a/Pareto/Checks/SublimeText.swift
+++ b/Pareto/Checks/SublimeText.swift
@@ -46,6 +46,7 @@ class AppSublimeTextCheck: AppCheck {
                 completion("\(version.prefix(1)).\(version.suffix(3)).0")
             } else {
                 os_log("%{public}s failed: %{public}s", self.appBundle, response.error.debugDescription)
+                self.hasError = true
                 completion("0.0.0")
             }
 

--- a/Pareto/Checks/System Integrity/TimeMachineHasBackup.swift
+++ b/Pareto/Checks/System Integrity/TimeMachineHasBackup.swift
@@ -36,6 +36,7 @@ class TimeMachineHasBackupCheck: ParetoCheck {
     override func checkPasses() -> Bool {
         guard let settings = readDefaultsFile(path: "/Library/Preferences/com.apple.TimeMachine.plist") as! [String: Any]? else {
             os_log("/Library/Preferences/com.apple.TimeMachine.plist is empty")
+            hasError = true
             return false
         }
         let tmConf = TimeMachineConfig(dict: settings)

--- a/Pareto/Checks/System Integrity/TimeMachineIsEncrypted.swift
+++ b/Pareto/Checks/System Integrity/TimeMachineIsEncrypted.swift
@@ -45,6 +45,7 @@ class TimeMachineIsEncryptedCheck: ParetoCheck {
     override func checkPasses() -> Bool {
         guard let settings = readDefaultsFile(path: "/Library/Preferences/com.apple.TimeMachine.plist") as! [String: Any]? else {
             os_log("/Library/Preferences/com.apple.TimeMachine.plist is empty")
+            hasError = true
             return false
         }
         let tmConf = TimeMachineConfig(dict: settings)

--- a/Pareto/Checks/VSCode.swift
+++ b/Pareto/Checks/VSCode.swift
@@ -39,6 +39,7 @@ class AppVSCodeCheck: AppCheck {
                 completion(version)
             } else {
                 os_log("%{public}s failed: %{public}s", self.appBundle, response.error.debugDescription)
+                self.hasError = true
                 completion("0.0.0")
             }
 

--- a/Pareto/Checks/Zoom.swift
+++ b/Pareto/Checks/Zoom.swift
@@ -51,6 +51,7 @@ class AppZoomCheck: AppCheck {
                 completion(version)
             } else {
                 os_log("%{public}s failed: %{public}s", self.appBundle, response.error.debugDescription)
+                self.hasError = true
                 completion("0.0.0")
             }
 

--- a/Pareto/Info.plist
+++ b/Pareto/Info.plist
@@ -26,7 +26,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>5664</string>
+	<string>5709</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/Pareto/ParetoApp.swift
+++ b/Pareto/ParetoApp.swift
@@ -184,7 +184,7 @@ class AppDelegate: AppHandlers, NSApplicationDelegate {
 
         // Migrate team ticket
         #if !SETAPP_ENABLED
-        TeamTicket.migrate()
+            TeamTicket.migrate()
         #endif
         statusBar = StatusBarController()
 

--- a/Pareto/Views/Settings/AboutSettingsView.swift
+++ b/Pareto/Views/Settings/AboutSettingsView.swift
@@ -105,7 +105,7 @@ struct AboutSettingsView: View {
                     Defaults[.updateNag] = false
                 }
             } else {
-                status = UpdateStates.Updated
+                status = UpdateStates.Failed
                 isLoading = false
             }
         }

--- a/ParetoSecurityTests/ApplicationUpdatesTest.swift
+++ b/ParetoSecurityTests/ApplicationUpdatesTest.swift
@@ -9,7 +9,6 @@
 import XCTest
 
 class ApplicationUpdatesTest: XCTestCase {
-
     func testAppVersionFetchers() throws {
         var redirects = [String]()
         var names = [String]()

--- a/ParetoSecurityTests/CheckIntegrationTest.swift
+++ b/ParetoSecurityTests/CheckIntegrationTest.swift
@@ -9,7 +9,6 @@
 import XCTest
 
 class CheckIntegrationTest: XCTestCase {
-
     func testInit() throws {
         let check = IntegrationCheck()
         check.configure()

--- a/ParetoSecurityTests/ParetoAppTest.swift
+++ b/ParetoSecurityTests/ParetoAppTest.swift
@@ -9,7 +9,6 @@
 import XCTest
 
 class ParetoAppTest: XCTestCase {
-
     func testActionEnrollTeam() throws {
         let app = AppHandlers()
         app.processAction(URL(string: "paretosecurity://enrollTeam")!)

--- a/ParetoSecurityTests/ParetoSecurityTests.swift
+++ b/ParetoSecurityTests/ParetoSecurityTests.swift
@@ -10,7 +10,6 @@ import Defaults
 import XCTest
 
 class ParetoSecurityTests: XCTestCase {
-
     func testThatUUIDsAreUnique() throws {
         var uuids: [String] = []
         for claim in Claims.global.all {

--- a/ParetoSecurityTests/SettingsTests.swift
+++ b/ParetoSecurityTests/SettingsTests.swift
@@ -10,7 +10,6 @@ import ViewInspector
 import XCTest
 
 class SettingsViewTests: XCTestCase {
-
     func testSettingsView() throws {
         let subject = SettingsView(selected: SettingsView.Tabs.general)
         let sub = try subject.inspect().implicitAnyView()
@@ -29,5 +28,4 @@ class SettingsViewTests: XCTestCase {
         let one = try subject.inspect().implicitAnyView().form()[0].text().string()
         XCTAssertEqual(one, "The Teams subscription will give you a web dashboard for an overview of the company’s devices.")
     }
-
 }

--- a/ParetoSecurityTests/TeamsTest.swift
+++ b/ParetoSecurityTests/TeamsTest.swift
@@ -20,7 +20,6 @@ mwIDAQAB
 """
 
 class TeamsTest: XCTestCase {
-
     func testLink() throws {
         Defaults[.teamID] = "fd4e6814-440c-46d2-b240-4e0d2f786fbc"
         Defaults[.teamAPI] = "http://localhost"
@@ -45,6 +44,19 @@ class TeamsTest: XCTestCase {
         _ = Team.update(withReport: report)
     }
 
+    func testReportError() throws {
+        for claim in Claims.global.all {
+            for check in claim.checks {
+                check.hasError = true
+                break
+            }
+        }
+
+        let report = Report.now()
+        XCTAssertEqual(report.state["2e46c89a-5461-4865-a92e-3b799c12034a"], "error")
+        XCTAssertEqual(report.state["b96524e0-850b-4bb9-abc7-517051b6c14e"], "pass")
+    }
+
     func testSettings() throws {
         Defaults[.teamID] = "fd4e6814-440c-46d2-b240-4e0d2f786fbc"
         Defaults[.teamAPI] = "http://localhost"
@@ -59,7 +71,7 @@ class TeamsTest: XCTestCase {
         let data = "eyJhbGciOiJSUzUxMiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJqdEBuaXRlby5jbyIsInRlYW1JRCI6IjI0MjljNDllLTM3YmItNDFiYi05MDc3LTZiYjYyMDJlMjU1YiIsInJvbGUiOiJ0ZWFtIiwiaWF0IjoxNjM0Mjk5NDI4LCJ0b2tlbiI6ImV5SjBlWEFpT2lKS1YxUWlMQ0poYkdjaU9pSklVelV4TWlKOS5leUp5YjJ4bGN5STZXeUpzYVc1clgyUmxkbWxqWlNJc0luVndaR0YwWlY5a1pYWnBZMlVpWFN3aWRHVmhiVjlwWkNJNklqSTBNamxqTkRsbExUTTNZbUl0TkRGaVlpMDVNRGMzTFRaaVlqWXlNREpsTWpVMVlpSXNJbk4xWWlJNkltcDBRRzVwZEdWdkxtTnZJaXdpYVdGMElqb3hOak0wTWprNU5ESTRmUS5LOHc0Sk5CYzFJN09fNzZ6MUxzR254REVjeUJwak96NzFac1FqTFVpWkpTMlJFUWt6RFVPeW1Zb2hRTk1LT0pBLU05RmM3aVFDWmhISkZjUmFjSng1QSJ9.sb8Q79nuIc0NQsiAye2VlLTZQJ5bxpE0r814Nla4zdPy8h_Iw026KXbx9WZo7qh9ZW9X7XXR7bEkk_T48cA7yjBS70amsEV1ZmgllOaHdhqFLqVhy4ny9IkvbqYqQa-pTHDrQ04wgFPr4EgE5Y2Ce6-8EfCGuJsN-OHZK-tmhgR1cJ7kiIundxDBdL-eZwLahx_jm495RBp08CgN0G7C7qIdr7BrM4N3Sz2UuuEoJK2SeAWEnNkD2XHk1617HjCv2lRfnjoKKNYZgemnE_uGBaSWAud2D90W8b5tqpbBV16dbzx_8Y9jVtmwmVfIOcB4RfMiPrcWbxVAUj9OBNvkCg"
         XCTAssertNoThrow(try TeamTicket.verify(withTicket: data, publicKey: publicKey))
     }
-    
+
     func testTeamTicketMigration() throws {
         // https://jwt.io/#debugger-io?token=eyJhbGciOiJSUzUxMiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZWFtQGRvbWFpbi5jb20iLCJyb2xlIjoidGVhbSIsInRlYW1JRCI6IjEyMzQiLCJ0ZWFtTmFtZSI6InRlYW1OYW1lIiwiZGV2aWNlSUQiOiI0NTY3IiwiaWF0IjoxNTE2MjM5MDIyfQ.VvKXwoTjWh127lYfPnHuEGGy3RpuvYvdGd0I-0XANiXaGSoDOXpaqM-Xs_UBcgylAEP3GArD65FLbXs2fJIlWRlYNuZ-iNHzDIdsLNqrqAA1BUx3naft8AATCmstuCOMtkNyi3-ZjNuq0ffafTIQqc1pGwfY5kkTYcVRlDDadV29iuK8Pl2NJl-WfoYkXHyqKoa0a1KyjTmwE1cyxdwcsrfHaZ3cujtrjpzO0uSyM-hBCFSul7okGlFwSjHP3Os0Onb3tflIAt4fPWB7K6LLhGF5FkgM0Aa7oNgi_T4nChmpCIb96sDJoKoXpAND312ZCCw8xSmn7LQnduC6tJBEuA&publicKey=-----BEGIN%20PUBLIC%20KEY-----%0AMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnzyis1ZjfNB0bBgKFMSv%0AvkTtwlvBsaJq7S5wA%2BkzeVOVpVWwkWdVha4s38XM%2Fpa%2Fyr47av7%2Bz3VTmvDRyAHc%0AaT92whREFpLv9cj5lTeJSibyr%2FMrm%2FYtjCZVWgaOYIhwrXwKLqPr%2F11inWsAkfIy%0AtvHWTxZYEcXLgAXFuUuaS3uF9gEiNQwzGTU1v0FqkqTBr4B8nW3HCN47XUu0t8Y0%0Ae%2Blf4s4OxQawWD79J9%2F5d3Ry0vbV3Am1FtGJiJvOwRsIfVChDpYStTcHTCMqtvWb%0AV6L11BWkpzGXSW4Hv43qa%2BGSYOD2QU68Mb59oSk2OB%2BBtOLpJofmbGEGgvmwyCI9%0AMwIDAQAB%0A-----END%20PUBLIC%20KEY-----
         let data = "eyJhbGciOiJSUzUxMiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJqdEBuaXRlby5jbyIsInRlYW1JRCI6IjI0MjljNDllLTM3YmItNDFiYi05MDc3LTZiYjYyMDJlMjU1YiIsInJvbGUiOiJ0ZWFtIiwiaWF0IjoxNjM0Mjk5NDI4LCJ0b2tlbiI6ImV5SjBlWEFpT2lKS1YxUWlMQ0poYkdjaU9pSklVelV4TWlKOS5leUp5YjJ4bGN5STZXeUpzYVc1clgyUmxkbWxqWlNJc0luVndaR0YwWlY5a1pYWnBZMlVpWFN3aWRHVmhiVjlwWkNJNklqSTBNamxqTkRsbExUTTNZbUl0TkRGaVlpMDVNRGMzTFRaaVlqWXlNREpsTWpVMVlpSXNJbk4xWWlJNkltcDBRRzVwZEdWdkxtTnZJaXdpYVdGMElqb3hOak0wTWprNU5ESTRmUS5LOHc0Sk5CYzFJN09fNzZ6MUxzR254REVjeUJwak96NzFac1FqTFVpWkpTMlJFUWt6RFVPeW1Zb2hRTk1LT0pBLU05RmM3aVFDWmhISkZjUmFjSng1QSJ9.sb8Q79nuIc0NQsiAye2VlLTZQJ5bxpE0r814Nla4zdPy8h_Iw026KXbx9WZo7qh9ZW9X7XXR7bEkk_T48cA7yjBS70amsEV1ZmgllOaHdhqFLqVhy4ny9IkvbqYqQa-pTHDrQ04wgFPr4EgE5Y2Ce6-8EfCGuJsN-OHZK-tmhgR1cJ7kiIundxDBdL-eZwLahx_jm495RBp08CgN0G7C7qIdr7BrM4N3Sz2UuuEoJK2SeAWEnNkD2XHk1617HjCv2lRfnjoKKNYZgemnE_uGBaSWAud2D90W8b5tqpbBV16dbzx_8Y9jVtmwmVfIOcB4RfMiPrcWbxVAUj9OBNvkCg"
@@ -68,16 +80,13 @@ class TeamsTest: XCTestCase {
         Defaults[.migrated] = false
         XCTAssertNoThrow(try TeamTicket.verify(withTicket: data, publicKey: publicKey))
         TeamTicket.migrate(publicKey: publicKey)
-        
+
         XCTAssertEqual(Defaults[.teamID], "2429c49e-37bb-41bb-9077-6bb6202e255b")
         XCTAssertTrue(Defaults[.migrated])
-        
     }
-
 
     func testTeamTicketFail() throws {
         let data = ""
         XCTAssertThrowsError(try TeamTicket.verify(withTicket: data, publicKey: publicKey))
     }
-
 }

--- a/ParetoSecurityTests/UpdaterTest.swift
+++ b/ParetoSecurityTests/UpdaterTest.swift
@@ -9,7 +9,6 @@
 import XCTest
 
 class UpdaterTest: XCTestCase {
-
     func testParsing() throws {
         let asset = [Release.Asset(name: "", browser_download_url: URL(string: "foo://")!, size: 1, content_type: Release.Asset.ContentType.zip)]
         let releases = [


### PR DESCRIPTION
- Introduced `hasError` property in `AppCheck` and its subclasses to track errors during version checks.

Can be merged before Dash changes, but not released. 

ref: https://github.com/teamniteo/pareto/issues/715