### PR TITLE
fix: broken app after update

### DIFF
--- a/Pareto/ParetoApp.swift
+++ b/Pareto/ParetoApp.swift
@@ -39,6 +39,7 @@ class AppDelegate: AppHandlers, NSApplicationDelegate {
         do {
             try fileManager.moveItem(atPath: bundlePath, toPath: destinationPath)
             print("Moved app to /Applications")
+            AppUpdater.clearExtendedAttributes(at: destinationPath)
 
         } catch {
             print("Failed to move the app: \(error)")


### PR DESCRIPTION
In some cases after the update the app binary gets broken and can't be open. The `xattr -cr` command fixes the binary and makes it runnable again.

The error before:
<img width="255" height="250" alt="image" src="https://github.com/user-attachments/assets/caf07821-9d82-40db-87df-091eee00396b" />
