### PR TITLE
fix: broken app after update

### DIFF
--- a/Pareto/ParetoApp.swift
+++ b/Pareto/ParetoApp.swift
@@ -37,12 +37,12 @@ class AppDelegate: AppHandlers, NSApplicationDelegate {
         }
 
         do {
-            try fileManager.moveItem(atPath: bundlePath, toPath: destinationPath)
+            try AppUpdater.safeCopyBundle(from: bundlePath, to: destinationPath)
             print("Moved app to /Applications")
-            AppUpdater.clearExtendedAttributes(at: destinationPath)
-
+            // Clean up original bundle after successful copy
+            try? fileManager.removeItem(atPath: bundlePath)
         } catch {
-            print("Failed to move the app: \(error)")
+            print("Failed to copy the app: \(error)")
         }
         exit(0) // Terminate old instance
     }


### PR DESCRIPTION
The issue was caused by:
- Using /usr/bin/unzip for extraction, which creates AppleDouble files (._* files) that invalidate the app's sealed resources
- Not properly preserving metadata when copying the updated app bundle

Use ditto instead of unzip to fix this issue.