### PR TITLE
feat: show notification when device is unlinked

### DIFF
--- a/Pareto/AppHandlers.swift
+++ b/Pareto/AppHandlers.swift
@@ -188,6 +188,12 @@ class AppHandlers: NSObject, ObservableObject, NetworkHandlerObserver {
                                 os_log("Team status was updated", log: Log.app)
                             case let .failure(err):
                                 os_log("Team status update failed: %s", log: Log.app, err.localizedDescription)
+
+                                // Check if the error is a 404 (device/team not found)
+                                if let statusCode = response.response?.statusCode, statusCode == 404 {
+                                    Team.showDeviceRemovedAlert()
+                                    os_log("Device disconnected from Cloud. Got team update response with 404 error", log: Log.app)
+                                }
                             }
                         }
                     }

--- a/Pareto/Defaults.swift
+++ b/Pareto/Defaults.swift
@@ -37,6 +37,7 @@ extension Defaults.Keys {
     static let machineUUID = Key<String>("machineUUID", default: AppInfo.getSystemUUID() ?? UUID().uuidString, suite: extensionDefaults)
     static let sendHWInfo = Key<Bool>("sendHWInfo", default: false, suite: extensionDefaults)
     static let lastHWAsk = Key<Int>("lastHWAsk", default: 0, suite: extensionDefaults)
+    static let lastDeviceRemovedAlert = Key<Int>("lastDeviceRemovedAlert", default: 0, suite: extensionDefaults)
 
     // Updates
     static let updateNag = Key<Bool>("updateNag", default: false, suite: extensionDefaults)
@@ -109,6 +110,11 @@ public extension Defaults {
 
     static func shouldAskForHWAllow() -> Bool {
         return Defaults[.lastHWAsk] + Date.HourInMs * 24 * 7 * 30 * 6 < Date().currentTimeMs()
+    }
+
+    static func shouldShowDeviceRemovedAlert() -> Bool {
+        // Show once per week
+        return Defaults[.lastDeviceRemovedAlert] + Date.HourInMs * 24 * 7 < Date().currentTimeMs()
     }
 
     static func shouldDoTeamUpdate() -> Bool {

--- a/Pareto/Info.plist
+++ b/Pareto/Info.plist
@@ -26,7 +26,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>6495</string>
+	<string>6498</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/ParetoSecurityTests/TeamsTest.swift
+++ b/ParetoSecurityTests/TeamsTest.swift
@@ -70,4 +70,38 @@ class TeamsTest: XCTestCase {
 
         XCTAssertEqual(response.auth, "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0ZWFtX2lkIjoiMjQyOWM0OWUtMzdiYi00MWJiLTkwNzctNmJiNjIwMmUyNTViIn0.test")
     }
+    
+    func testShouldShowDeviceRemovedAlertFirstTime() throws {
+        // Reset the last alert timestamp
+        Defaults[.lastDeviceRemovedAlert] = 0
+        
+        // Should show alert when never shown before
+        XCTAssertTrue(Defaults.shouldShowDeviceRemovedAlert())
+    }
+    
+    func testShouldShowDeviceRemovedAlertAfterWeek() throws {
+        // Set last alert to more than a week ago
+        let moreThanWeekAgo = Date().currentTimeMs() - (Date.HourInMs * 24 * 8)
+        Defaults[.lastDeviceRemovedAlert] = moreThanWeekAgo
+        
+        // Should show alert after a week has passed
+        XCTAssertTrue(Defaults.shouldShowDeviceRemovedAlert())
+    }
+    
+    func testShouldNotShowDeviceRemovedAlertWithinWeek() throws {
+        // Set last alert to less than a week ago (e.g., 3 days ago)
+        let threeDaysAgo = Date().currentTimeMs() - (Date.HourInMs * 24 * 3)
+        Defaults[.lastDeviceRemovedAlert] = threeDaysAgo
+        
+        // Should not show alert within a week
+        XCTAssertFalse(Defaults.shouldShowDeviceRemovedAlert())
+    }
+    
+    func testShouldNotShowDeviceRemovedAlertJustShown() throws {
+        // Set last alert to now
+        Defaults[.lastDeviceRemovedAlert] = Date().currentTimeMs()
+        
+        // Should not show alert immediately after showing
+        XCTAssertFalse(Defaults.shouldShowDeviceRemovedAlert())
+    }
 }


### PR DESCRIPTION
When device is unlinked (404 response to state PATCH or 404 on Team settings), show alert with help text.

User can then manually unlink the device from the app preferences or contact administrator of Pareto Cloud to link the device again.

Ref: https://github.com/teamniteo/pareto/issues/705#issuecomment-3227494687