### PR TITLE
fix: No option to enable once disabled check

### DIFF
--- a/Pareto/Checks/Access Security/NoUnusedUsers.swift
+++ b/Pareto/Checks/Access Security/NoUnusedUsers.swift
@@ -25,14 +25,14 @@ class NoUnusedUsers: ParetoCheck {
     }
 
     // MARK: - User status enum
-    
+
     enum UserStatus {
         case pass(reason: String)
         case fail(reason: String)
     }
 
     // MARK: - Public computed properties
-    
+
     // Get all users with their statuses
     var allUserStatuses: [(user: String, status: UserStatus)] {
         Self.localUserShortNames()
@@ -53,16 +53,16 @@ class NoUnusedUsers: ParetoCheck {
 
     override var details: String {
         let statuses = allUserStatuses
-        
+
         guard !statuses.isEmpty else {
             return "No user accounts found"
         }
-        
+
         return statuses.map { userStatus in
             switch userStatus.status {
-            case .pass(let reason):
+            case let .pass(reason):
                 return "* [PASS] \(userStatus.user): \(reason)"
-            case .fail(let reason):
+            case let .fail(reason):
                 return "* [FAIL] \(userStatus.user): \(reason)"
             }
         }.joined(separator: "\n")
@@ -84,32 +84,32 @@ private extension NoUnusedUsers {
         let currentUser = NSUserName()
         let adminSet = Self.adminUserShortNames()
         let ignoredUsers = Set(Defaults[.ignoredUserAccounts])
-        
+
         // Check reasons for PASS
         if user == currentUser {
             return .pass(reason: "current account")
         }
-        
+
         if adminSet.contains(user) {
             return .pass(reason: "admin account")
         }
-        
+
         if ignoredUsers.contains(user) {
             return .pass(reason: "ignored by user")
         }
-        
+
         // Check if recently logged in
         let thresholdDays = Self.recentLoginDays
         let cutoff = Date().addingTimeInterval(-TimeInterval(thresholdDays) * 24 * 60 * 60)
-        
+
         if let lastLogin = Self.lastLoginDate(for: user), lastLogin >= cutoff {
             return .pass(reason: "recently logged in")
         }
-        
+
         // Otherwise it's an unused account
         return .fail(reason: "unused account")
     }
-    
+
     // Threshold for "recent" login
     static let recentLoginDays: Int = 7
 

--- a/Pareto/Checks/Access Security/PasswordtoUnlock.swift
+++ b/Pareto/Checks/Access Security/PasswordtoUnlock.swift
@@ -29,4 +29,24 @@ class RequirePasswordToUnlock: ParetoCheck {
         let out = runOSA(appleScript: script) ?? "false"
         return out.contains("true")
     }
+
+    override var details: String {
+        let script = "tell application \"System Events\" to tell security preferences to get require password to unlock"
+        let rawOut = runOSA(appleScript: script)
+        let interpreted: String
+        if let out = rawOut {
+            if out.contains("true") {
+                interpreted = "enabled"
+            } else if out.contains("false") {
+                interpreted = "disabled"
+            } else {
+                interpreted = "unknown"
+            }
+        } else {
+            interpreted = "error (nil output)"
+        }
+
+        // Keep it debug-focused: show raw OSA output and our interpretation.
+        return "OSA output: \(rawOut ?? "nil"); interpreted: \(interpreted)"
+    }
 }

--- a/Pareto/Checks/Firewall and Sharing/Firewall.swift
+++ b/Pareto/Checks/Firewall and Sharing/Firewall.swift
@@ -30,10 +30,6 @@ class FirewallCheck: ParetoCheck {
         "Firewall is off"
     }
 
-    override var isCritical: Bool {
-        return true
-    }
-
     override var requiresHelper: Bool {
         if #available(macOS 26, *) {
             return false

--- a/Pareto/Checks/ParetoCheck.swift
+++ b/Pareto/Checks/ParetoCheck.swift
@@ -242,10 +242,6 @@ class ParetoCheck: Hashable, ObservableObject, Identifiable {
         return item
     }
 
-    var isCritical: Bool {
-        return false
-    }
-
     var CIS: String {
         return "0"
     }
@@ -288,21 +284,13 @@ class ParetoCheck: Hashable, ObservableObject, Identifiable {
 
         os_log("Running check for %{public}s - %{public}s", log: Log.app, UUID, Title)
         hasError = false
-        var result = checkPasses()
-
-        // If this check is required by the team but the user has it disabled,
-        // still consider it failing to surface policy violations.
-        var overrideDetails: String?
-        if teamEnforced && !storedIsActive {
-            result = false
-            overrideDetails = "Disabled locally but required by team"
-        }
+        let result = checkPasses()
 
         checkPassed = result
         checkTimestamp = Int(Date().currentTimeMs())
 
         // Cache the details after running the check
-        cachedDetails = overrideDetails ?? details
+        cachedDetails = details
 
         // Notify UI observers that this check changed
         DispatchQueue.main.async {

--- a/Pareto/Checks/System Integrity/OpenWiFi.swift
+++ b/Pareto/Checks/System Integrity/OpenWiFi.swift
@@ -31,10 +31,6 @@ class OpenWiFiCheck: ParetoCheck {
         return CWWiFiClient.shared().interface(withName: nil)?.security() != CWSecurity.none
     }
 
-    override var isCritical: Bool {
-        return true
-    }
-
     var isRoutedViaVPN: Bool {
         let data = runCMD(app: "/usr/sbin/netstat", args: ["-rnt"])
 
@@ -56,6 +52,57 @@ class OpenWiFiCheck: ParetoCheck {
             }
         }
         return false
+    }
+
+    private func securityDescription(_ security: CWSecurity?) -> String {
+        guard let s = security else { return "Unknown" }
+        switch s {
+        case .none: return "Open (no encryption)"
+        case .WEP: return "WEP"
+        case .wpaPersonal: return "WPA Personal"
+        case .wpaPersonalMixed: return "WPA/WPA2 Personal (mixed)"
+        case .wpa2Personal: return "WPA2 Personal"
+        case .personal: return "Personal"
+        case .dynamicWEP: return "Dynamic WEP"
+        case .wpaEnterprise: return "WPA Enterprise"
+        case .wpaEnterpriseMixed: return "WPA/WPA2 Enterprise (mixed)"
+        case .wpa2Enterprise: return "WPA2 Enterprise"
+        case .enterprise: return "Enterprise"
+        case .wpa3Personal: return "WPA3 Personal"
+        case .wpa3Enterprise: return "WPA3 Enterprise"
+        case .wpa3Transition: return "WPA2/WPA3 Personal (transition)"
+        case .unknown: return "Unknown"
+        case .OWE:
+            return "OWE"
+        case .oweTransition:
+            return "oweTransition"
+        @unknown default: return "Unknown"
+        }
+    }
+
+    override var details: String {
+        guard let iface = CWWiFiClient.shared().interface(withName: nil) else {
+            return "Could not access Wi‑Fi interface"
+        }
+
+        // Not runnable scenario context
+        if !isWiFiActive {
+            return "Wi‑Fi is not active"
+        }
+
+        let ssid = iface.ssid() ?? "Unknown SSID"
+        let security = iface.security()
+        let securityText = securityDescription(security)
+
+        if isRoutedViaVPN {
+            return "Traffic routed via VPN while connected to '\(ssid)' (\(securityText))"
+        }
+
+        if security != .none {
+            return "Connected to secured Wi‑Fi '\(ssid)' (\(securityText))"
+        } else {
+            return "Connected to open Wi‑Fi '\(ssid)' without encryption"
+        }
     }
 
     override func checkPasses() -> Bool {

--- a/Pareto/Info.plist
+++ b/Pareto/Info.plist
@@ -26,7 +26,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>6737</string>
+	<string>6742</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/Pareto/ParetoApp.swift
+++ b/Pareto/ParetoApp.swift
@@ -252,7 +252,6 @@ struct Pareto: App {
         .windowStyle(.hiddenTitleBar)
         .defaultSize(width: 1, height: 1)
 
-
         // Welcome window managed by SwiftUI, with no controls
         WindowGroup("Welcome", id: AppWindowID.welcome) {
             WelcomeView()
@@ -282,7 +281,7 @@ struct Pareto: App {
                     NSApp.activate(ignoringOtherApps: true)
                 }
         }
-        
+
         // Menu bar UI
         MenuBarExtra(isInserted: .constant(true)) {
             StatusBarMenuView(statusBarModel: appDelegate.statusBarModel)

--- a/Pareto/Views/Settings/AboutSettingsView.swift
+++ b/Pareto/Views/Settings/AboutSettingsView.swift
@@ -69,16 +69,12 @@ struct AboutSettingsView: View {
             // App details
             GroupBox {
                 VStack(alignment: .leading, spacing: 6) {
-                   
-                        Text("Version \(AppInfo.appVersion) • Build \(AppInfo.buildVersion)")
-                            .fixedSize(horizontal: false, vertical: true)
-                            .layoutPriority(1)
-                    
+                    Text("Version \(AppInfo.appVersion) • Build \(AppInfo.buildVersion)")
+                        .fixedSize(horizontal: false, vertical: true)
+                        .layoutPriority(1)
 
-                   
-                        Text("Channel: \(AppInfo.utmSource)")
-                            .fixedSize(horizontal: false, vertical: true)
-            
+                    Text("Channel: \(AppInfo.utmSource)")
+                        .fixedSize(horizontal: false, vertical: true)
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
             } label: {
@@ -88,54 +84,54 @@ struct AboutSettingsView: View {
 
             // Updates
             #if !SETAPP_ENABLED
-            GroupBox {
-                VStack(alignment: .leading, spacing: 8) {
-                    HStack(alignment: .firstTextBaseline, spacing: 10) {
-                        Label {
-                            Text(updateStatusText)
-                                .fixedSize(horizontal: false, vertical: true)
-                                .layoutPriority(1)
-                        } icon: {
-                            Image(systemName: updateStatusSymbol)
-                                .foregroundStyle(updateStatusColor)
-                        }
-
-                        if self.isLoading {
-                            ProgressView()
-                                .controlSize(.small)
-                        }
-
-                        Spacer(minLength: 0)
-
-                        // Inline "Install Update" button when a new version is found
-                        if hasCheckedForUpdates && status == UpdateStates.NewVersion {
-                            Button {
-                                forceUpdate()
-                            } label: {
-                                Label("Install Update", systemImage: "square.and.arrow.down")
-                                    .labelStyle(.titleAndIcon)
+                GroupBox {
+                    VStack(alignment: .leading, spacing: 8) {
+                        HStack(alignment: .firstTextBaseline, spacing: 10) {
+                            Label {
+                                Text(updateStatusText)
+                                    .fixedSize(horizontal: false, vertical: true)
+                                    .layoutPriority(1)
+                            } icon: {
+                                Image(systemName: updateStatusSymbol)
+                                    .foregroundStyle(updateStatusColor)
                             }
-                            .disabled(isLoading)
-                            .buttonStyle(.borderedProminent)
-                        }
 
-                        // Inline "Check for Updates" button when appropriate
-                        if !hasCheckedForUpdates || status == UpdateStates.Updated {
-                            Button {
-                                fetch()
-                            } label: {
-                                Label("Check for Updates", systemImage: "arrow.triangle.2.circlepath")
-                                    .labelStyle(.titleAndIcon)
+                            if self.isLoading {
+                                ProgressView()
+                                    .controlSize(.small)
                             }
-                            .disabled(isLoading)
-                            .buttonStyle(.bordered)
+
+                            Spacer(minLength: 0)
+
+                            // Inline "Install Update" button when a new version is found
+                            if hasCheckedForUpdates && status == UpdateStates.NewVersion {
+                                Button {
+                                    forceUpdate()
+                                } label: {
+                                    Label("Install Update", systemImage: "square.and.arrow.down")
+                                        .labelStyle(.titleAndIcon)
+                                }
+                                .disabled(isLoading)
+                                .buttonStyle(.borderedProminent)
+                            }
+
+                            // Inline "Check for Updates" button when appropriate
+                            if !hasCheckedForUpdates || status == UpdateStates.Updated {
+                                Button {
+                                    fetch()
+                                } label: {
+                                    Label("Check for Updates", systemImage: "arrow.triangle.2.circlepath")
+                                        .labelStyle(.titleAndIcon)
+                                }
+                                .disabled(isLoading)
+                                .buttonStyle(.bordered)
+                            }
                         }
                     }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                } label: {
+                    Text("Updates")
                 }
-                .frame(maxWidth: .infinity, alignment: .leading)
-            } label: {
-                Text("Updates")
-            }
             #endif
 
             Divider()
@@ -216,17 +212,17 @@ struct AboutSettingsView: View {
 
     private func fetch() {
         #if SETAPP_ENABLED
-        DispatchQueue.main.async {
-            isLoading = false
-            status = UpdateStates.Failed
-            let alert = NSAlert()
-            alert.messageText = "Update is not available in SetApp version"
-            alert.informativeText = "Please use SetApp to update the application"
-            alert.alertStyle = NSAlert.Style.informational
-            alert.addButton(withTitle: "OK")
-            alert.runModal()
-        }
-        return
+            DispatchQueue.main.async {
+                isLoading = false
+                status = UpdateStates.Failed
+                let alert = NSAlert()
+                alert.messageText = "Update is not available in SetApp version"
+                alert.informativeText = "Please use SetApp to update the application"
+                alert.alertStyle = NSAlert.Style.informational
+                alert.addButton(withTitle: "OK")
+                alert.runModal()
+            }
+            return
         #endif
 
         DispatchQueue.global(qos: .userInteractive).async {
@@ -273,17 +269,17 @@ struct AboutSettingsView: View {
 
             if let release = try? updater.getLatestRelease() {
                 #if SETAPP_ENABLED
-                DispatchQueue.main.async {
-                    isLoading = false
-                    status = UpdateStates.Failed
-                    let alert = NSAlert()
-                    alert.messageText = "Force update is not available in SetApp version"
-                    alert.informativeText = "Please use SetApp to update the application"
-                    alert.alertStyle = NSAlert.Style.informational
-                    alert.addButton(withTitle: "OK")
-                    alert.runModal()
-                }
-                return
+                    DispatchQueue.main.async {
+                        isLoading = false
+                        status = UpdateStates.Failed
+                        let alert = NSAlert()
+                        alert.messageText = "Force update is not available in SetApp version"
+                        alert.informativeText = "Please use SetApp to update the application"
+                        alert.alertStyle = NSAlert.Style.informational
+                        alert.addButton(withTitle: "OK")
+                        alert.runModal()
+                    }
+                    return
                 #endif
 
                 if let zipURL = release.assets.filter({ $0.browser_download_url.path.hasSuffix(".zip") }).first {

--- a/Pareto/Views/Settings/CloudSettings.swift
+++ b/Pareto/Views/Settings/CloudSettings.swift
@@ -1,5 +1,5 @@
 //
-//  TeamSettings.swift
+//  CloudSettings.swift
 //  TeamSettings
 //
 //  Created by Janez Troha on 10/09/2021.
@@ -165,4 +165,3 @@ struct TeamSettingsView: View {
         }
     }
 }
-

--- a/Pareto/Views/StatusBarMenuView.swift
+++ b/Pareto/Views/StatusBarMenuView.swift
@@ -7,8 +7,8 @@
 
 import AppKit
 import Defaults
-import SwiftUI
 import SettingsAccess
+import SwiftUI
 
 struct StatusBarMenuView: View {
     @ObservedObject var statusBarModel: StatusBarModel


### PR DESCRIPTION
Removed reason for details override and added  proper details that will give us more information about the actual state for both wifi and unlock checks.

ref: https://github.com/ParetoSecurity/pareto-mac/issues/213