### PR TITLE
chore: stop sending LastCheck timestamp

### DIFF
--- a/Pareto/Info.plist
+++ b/Pareto/Info.plist
@@ -26,7 +26,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>6758</string>
+	<string>6759</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/Pareto/Teams.swift
+++ b/Pareto/Teams.swift
@@ -92,7 +92,6 @@ struct Report: Encodable {
     let disabledCount: Int
     let device: ReportingDevice
     let version: String
-    let lastCheck: String
     let significantChange: String
     let state: [String: String]
     let sbom: [PublicApp]
@@ -144,7 +143,6 @@ struct Report: Encodable {
             disabledCount: disabled,
             device: ReportingDevice.current(),
             version: AppInfo.appVersion,
-            lastCheck: Date.fromTimeStamp(timeStamp: Defaults[.lastCheck]).as3339String(),
             significantChange: SHA256.hash(data: "\(disabledSeed).\(failedSeed)".data(using: .utf8)!).hexStr,
             state: checkStates,
             sbom: sendSerial ? PublicApp.all : []


### PR DESCRIPTION
Cloud app no longer require this timestamp.

Ref: https://github.com/teamniteo/pareto/issues/723