### PR TITLE
feat: Prefer higer version of app, unstable only if enabled

### DIFF
--- a/Pareto/Info.plist
+++ b/Pareto/Info.plist
@@ -26,7 +26,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>6947</string>
+	<string>6952</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/Pareto/Views/Settings/AboutSettingsView.swift
+++ b/Pareto/Views/Settings/AboutSettingsView.swift
@@ -245,12 +245,13 @@ struct AboutSettingsView: View {
             let updater = AppUpdater(owner: "ParetoSecurity", repo: "pareto-mac")
             let currentVersion = Bundle.main.version
 
-            if let release = try? await updater.getLatestRelease() {
+            do {
+                let release = try await updater.getLatestRelease()
                 await MainActor.run {
                     hasCheckedForUpdates = true
                     isLoading = false
 
-                    if currentVersion < release.version {
+                    if let release, currentVersion < release.version {
                         status = UpdateStates.NewVersion
                         latestVersionFound = release.tag_name
                     } else {
@@ -259,7 +260,7 @@ struct AboutSettingsView: View {
                         Defaults[.updateNag] = false
                     }
                 }
-            } else {
+            } catch {
                 await MainActor.run {
                     hasCheckedForUpdates = true
                     status = UpdateStates.Failed

--- a/ParetoSecurityTests/UpdateServiceTest.swift
+++ b/ParetoSecurityTests/UpdateServiceTest.swift
@@ -4,6 +4,7 @@
 //
 
 @testable import Pareto_Security
+import Version
 import XCTest
 
 class UpdateServiceTest: XCTestCase {
@@ -83,18 +84,18 @@ class UpdateServiceTest: XCTestCase {
         // Test Release array filtering without network dependency
         let mockAsset = Release.Asset(name: "test.zip", browser_download_url: URL(string: "https://example.com/test.zip")!, size: 1000, content_type: .zip)
         let mockReleases = [
-            Release(tag_name: "v1.0.0", body: "", prerelease: false, html_url: URL(string: "https://example.com")!, published_at: "2024-01-01T00:00:00Z", assets: [mockAsset]),
-            Release(tag_name: "v1.1.0-beta", body: "", prerelease: true, html_url: URL(string: "https://example.com")!, published_at: "2024-02-01T00:00:00Z", assets: [mockAsset]),
+            Release(tag_name: "v1.12.0", body: "", prerelease: false, html_url: URL(string: "https://example.com")!, published_at: "2024-01-01T00:00:00Z", assets: [mockAsset]),
+            Release(tag_name: "v1.12.1", body: "", prerelease: true, html_url: URL(string: "https://example.com")!, published_at: "2024-02-01T00:00:00Z", assets: [mockAsset]),
         ]
 
         // Test that we can find a viable update
-        let viableUpdate = try mockReleases.findViableUpdate(prerelease: false)
+        let viableUpdate = try mockReleases.findViableUpdate(prerelease: false, currentVersion: Version(1, 11, 0))
         XCTAssertNotNil(viableUpdate, "Should find a viable non-prerelease update")
-        XCTAssertEqual(viableUpdate?.tag_name, "v1.0.0", "Should return stable release")
+        XCTAssertEqual(viableUpdate?.tag_name, "v1.12.0", "Should return stable release")
 
         // Test prerelease filtering
-        let prereleaseUpdate = try mockReleases.findViableUpdate(prerelease: true)
+        let prereleaseUpdate = try mockReleases.findViableUpdate(prerelease: true, currentVersion: Version(1, 12, 0))
         XCTAssertNotNil(prereleaseUpdate, "Should find a viable prerelease update")
-        XCTAssertEqual(prereleaseUpdate?.tag_name, "v1.1.0-beta", "Should return prerelease")
+        XCTAssertEqual(prereleaseUpdate?.tag_name, "v1.12.1", "Should return prerelease")
     }
 }

--- a/ParetoSecurityTests/UpdaterTest.swift
+++ b/ParetoSecurityTests/UpdaterTest.swift
@@ -6,16 +6,48 @@
 //
 
 @testable import Pareto_Security
+import Version
 import XCTest
 
 class UpdaterTest: XCTestCase {
-    func testParsing() throws {
+    func testFindViableUpdateStableChannel() throws {
         let asset = [Release.Asset(name: "", browser_download_url: URL(string: "foo://")!, size: 1, content_type: Release.Asset.ContentType.zip)]
         let releases = [
-            Release(tag_name: "1.1.1", body: "", prerelease: true, html_url: URL(string: "foo://")!, published_at: "2025-01-01T00:00:00Z", assets: asset),
-            Release(tag_name: "1.0.0", body: "", prerelease: false, html_url: URL(string: "foo://")!, published_at: "2024-12-01T00:00:00Z", assets: asset),
+            Release(tag_name: "1.13.1", body: "", prerelease: true, html_url: URL(string: "foo://")!, published_at: "2025-01-01T00:00:00Z", assets: asset),
+            Release(tag_name: "1.13.0", body: "", prerelease: false, html_url: URL(string: "foo://")!, published_at: "2024-12-01T00:00:00Z", assets: asset),
+            Release(tag_name: "1.12.0", body: "", prerelease: false, html_url: URL(string: "foo://")!, published_at: "2024-11-01T00:00:00Z", assets: asset),
         ]
-        XCTAssertEqual(try! releases.findViableUpdate(prerelease: false)?.tag_name, "1.0.0")
-        XCTAssertEqual(try! releases.findViableUpdate(prerelease: true)?.tag_name, "1.1.1")
+
+        XCTAssertEqual(try releases.findViableUpdate(prerelease: false, currentVersion: Version(1, 11, 0))?.tag_name, "1.13.0")
+    }
+
+    func testFindViableUpdatePrereleaseChannelPrefersHighestAcrossChannels() throws {
+        let asset = [Release.Asset(name: "", browser_download_url: URL(string: "foo://")!, size: 1, content_type: Release.Asset.ContentType.zip)]
+        let releases = [
+            Release(tag_name: "1.12.3", body: "", prerelease: true, html_url: URL(string: "foo://")!, published_at: "2025-01-01T00:00:00Z", assets: asset),
+            Release(tag_name: "1.13.0", body: "", prerelease: false, html_url: URL(string: "foo://")!, published_at: "2025-01-02T00:00:00Z", assets: asset),
+        ]
+
+        XCTAssertEqual(try releases.findViableUpdate(prerelease: true, currentVersion: Version(1, 12, 2))?.tag_name, "1.13.0")
+    }
+
+    func testFindViableUpdatePrereleaseChannelSelectsPrereleaseWhenHigherThanStable() throws {
+        let asset = [Release.Asset(name: "", browser_download_url: URL(string: "foo://")!, size: 1, content_type: Release.Asset.ContentType.zip)]
+        let releases = [
+            Release(tag_name: "1.12.3", body: "", prerelease: true, html_url: URL(string: "foo://")!, published_at: "2025-01-03T00:00:00Z", assets: asset),
+            Release(tag_name: "1.12.0", body: "", prerelease: false, html_url: URL(string: "foo://")!, published_at: "2025-01-02T00:00:00Z", assets: asset),
+        ]
+
+        XCTAssertEqual(try releases.findViableUpdate(prerelease: true, currentVersion: Version(1, 12, 1))?.tag_name, "1.12.3")
+    }
+
+    func testFindViableUpdateReturnsNilWhenNothingIsNewer() throws {
+        let asset = [Release.Asset(name: "", browser_download_url: URL(string: "foo://")!, size: 1, content_type: Release.Asset.ContentType.zip)]
+        let releases = [
+            Release(tag_name: "1.12.1", body: "", prerelease: true, html_url: URL(string: "foo://")!, published_at: "2025-01-01T00:00:00Z", assets: asset),
+            Release(tag_name: "1.12.0", body: "", prerelease: false, html_url: URL(string: "foo://")!, published_at: "2025-01-02T00:00:00Z", assets: asset),
+        ]
+
+        XCTAssertNil(try releases.findViableUpdate(prerelease: true, currentVersion: Version(1, 12, 1)))
     }
 }


### PR DESCRIPTION
- Stable users (prerelease: false): only stable releases are considered.
- Pre-release users (prerelease: true): both stable + pre-release are considered.
- Candidate must have assets and be strictly newer than current version.
