### PR TITLE
Fix: macOS version parser

### DIFF
--- a/Pareto/Checks/AppCheck.swift
+++ b/Pareto/Checks/AppCheck.swift
@@ -91,7 +91,7 @@ class AppCheck: ParetoCheck, AppCheckProtocol {
             return
         }
         os_log("Requesting %{public}s", request.debugDescription)
-        AF.request(viaEdgeCache(request.description)).responseDecodable(of: AppStoreResponse.self, queue: AppCheck.queue, completionHandler: { response in
+        Network.session.request(viaEdgeCache(request.description)).responseDecodable(of: AppStoreResponse.self, queue: AppCheck.queue, completionHandler: { response in
             if let version = response.value?.results.first, response.error == nil {
                 completion(version.version)
                 return
@@ -214,7 +214,7 @@ class AppCheck: ParetoCheck, AppCheckProtocol {
             os_log("Requesting %{public}s", sparkleURL)
             let versionRegex = Regex("sparkle:shortVersionString=\"([\\.\\d]+)\"")
             let versionFallbackRegex = Regex("sparkle:version=\"([\\.\\d]+)\"")
-            AF.request(sparkleURL).responseString(queue: AppCheck.queue, completionHandler: { response in
+            Network.session.request(sparkleURL).responseString(queue: AppCheck.queue, completionHandler: { response in
                 if response.error == nil {
                     let versionNew = versionRegex.allMatches(in: response.value ?? "")
                     let versionOld = versionFallbackRegex.allMatches(in: response.value ?? "")

--- a/Pareto/Checks/Application Updates/1Password8.swift
+++ b/Pareto/Checks/Application Updates/1Password8.swift
@@ -23,7 +23,7 @@ class App1Password8Check: AppCheck {
         let url = "https://releases.1password.com/mac/8.9/"
         let versionRegex = Regex("([\\d\\.]+)</h6>")
         os_log("Requesting %{public}s", url)
-        AF.request(url).responseString(queue: AppCheck.queue, completionHandler: { response in
+        Network.session.request(url).responseString(queue: AppCheck.queue, completionHandler: { response in
             if response.data != nil {
                 let result = versionRegex.allMatches(in: response.value ?? "8.9.1")
 

--- a/Pareto/Checks/Application Updates/AdobeReader.swift
+++ b/Pareto/Checks/Application Updates/AdobeReader.swift
@@ -28,7 +28,7 @@ class AdobeReaderCheck: AppCheck {
         let linksRegex = Regex("<a .+ReleaseNotesDC.+>(.+)</a>")
         let versionRegex = Regex(".+\\((.+)\\)")
         os_log("Requesting %{public}s", url)
-        AF.request(url).responseString(queue: AppCheck.queue, completionHandler: { response in
+        Network.session.request(url).responseString(queue: AppCheck.queue, completionHandler: { response in
             if response.data != nil {
                 let links = linksRegex.firstMatch(in: response.value ?? "")
                 let result = versionRegex.firstMatch(in: links?.groups.first?.value ?? "DC Sep 2021 (21.007.2009x)")

--- a/Pareto/Checks/Application Updates/Docker.swift
+++ b/Pareto/Checks/Application Updates/Docker.swift
@@ -27,7 +27,7 @@ class AppDockerCheck: AppCheck {
         let url = viaEdgeCache("https://raw.githubusercontent.com/docker/docker.github.io/master/desktop/mac/release-notes/index.md")
         let versionRegex = Regex("## Docker Desktop ([\\d.]+)")
         os_log("Requesting %{public}s", url)
-        AF.request(url).responseString(queue: AppCheck.queue, completionHandler: { response in
+        Network.session.request(url).responseString(queue: AppCheck.queue, completionHandler: { response in
             if response.data != nil {
                 let result = versionRegex.firstMatch(in: response.value ?? "")
                 completion(result?.groups.first?.value ?? "0.0.0")

--- a/Pareto/Checks/Application Updates/MicrosoftTeams.swift
+++ b/Pareto/Checks/Application Updates/MicrosoftTeams.swift
@@ -49,7 +49,7 @@ class AppMicrosoftTeamsCheck: AppCheck {
         let url = viaEdgeCache("https://config.teams.microsoft.com/config/v1/MicrosoftTeams/1415_1.0.0.0?environment=prod&audienceGroup=general&teamsRing=general&agent=TeamsBuilds")
 
         os_log("Requesting %{public}s", url)
-        AF.request(url).responseDecodable(of: TeamsResponse.self, queue: AppCheck.queue, completionHandler: { response in
+        Network.session.request(url).responseDecodable(of: TeamsResponse.self, queue: AppCheck.queue, completionHandler: { response in
             if response.error == nil {
                 let v = response.value?.buildSettings?.webView2?.macOS?.latestVersion
                 completion(v ?? "0.0.0")

--- a/Pareto/Checks/Firefox.swift
+++ b/Pareto/Checks/Firefox.swift
@@ -42,7 +42,7 @@ class AppFirefoxCheck: AppCheck {
     override func getLatestVersion(completion: @escaping (String) -> Void) {
         let url = viaEdgeCache("https://product-details.mozilla.org/1.0/firefox_versions.json")
         os_log("Requesting %{public}s", url)
-        AF.request(url).responseDecodable(of: FirefoxVersions.self, queue: AppCheck.queue) { response in
+        Network.session.request(url).responseDecodable(of: FirefoxVersions.self, queue: AppCheck.queue) { response in
             if response.error == nil {
                 let version = response.value?.LATEST_FIREFOX_VERSION ?? "0.0.0"
                 os_log("%{public}s version=%{public}s", self.appBundle, version)

--- a/Pareto/Checks/GoogleChrome.swift
+++ b/Pareto/Checks/GoogleChrome.swift
@@ -52,7 +52,7 @@ class AppGoogleChromeCheck: AppCheck {
     override func getLatestVersion(completion: @escaping (String) -> Void) {
         let url = viaEdgeCache("https://versionhistory.googleapis.com/v1/chrome/platforms/mac/channels/stable/versions/all/releases?filter=endtime=none")
         os_log("Requesting %{public}s", url)
-        AF.request(url).responseDecodable(of: GoogleResponse.self, queue: AppCheck.queue, completionHandler: { response in
+        Network.session.request(url).responseDecodable(of: GoogleResponse.self, queue: AppCheck.queue, completionHandler: { response in
             if response.error == nil {
                 let v = response.value?.releases.filter { v in
                     v.fraction >= 0.9

--- a/Pareto/Checks/LibreOffice.swift
+++ b/Pareto/Checks/LibreOffice.swift
@@ -39,7 +39,7 @@ class AppLibreOfficeCheck: AppCheck {
         let url = viaEdgeCache("https://www.libreoffice.org/download/download/")
         os_log("Requesting %{public}s", url)
         let versionRegex = Regex("<span class=\"dl_version_number\">?([\\.\\d]+)</span>")
-        AF.request(url).responseString(queue: AppCheck.queue, completionHandler: { response in
+        Network.session.request(url).responseString(queue: AppCheck.queue, completionHandler: { response in
             if response.error == nil {
                 let html = response.value ?? "<span class=\"dl_version_number\">1.2.4</span>"
                 let versions = versionRegex.allMatches(in: html).map { $0.groups.first?.value ?? "1.2.4" }

--- a/Pareto/Checks/LuLu.swift
+++ b/Pareto/Checks/LuLu.swift
@@ -30,7 +30,7 @@ class AppLuLuCheck: AppCheck {
         let versionRegex = Regex("VERSION ([\\.\\d]+) ")
         os_log("Requesting %{public}s", url)
 
-        AF.request(url).responseString(queue: AppCheck.queue, completionHandler: { response in
+        Network.session.request(url).responseString(queue: AppCheck.queue, completionHandler: { response in
             if response.error == nil {
                 let txt = response.value ?? "VERSION 1.4.1 (11/01/2021)"
                 let version = versionRegex.firstMatch(in: txt)?.groups.first?.value ?? "1.4.1"

--- a/Pareto/Checks/Signal.swift
+++ b/Pareto/Checks/Signal.swift
@@ -30,7 +30,7 @@ class AppSignalCheck: AppCheck {
         let versionRegex = Regex("version: ?([\\.\\d]+)")
         os_log("Requesting %{public}s", url)
 
-        AF.request(url).responseString(queue: AppCheck.queue, completionHandler: { response in
+        Network.session.request(url).responseString(queue: AppCheck.queue, completionHandler: { response in
             if response.error == nil {
                 let yaml = response.value ?? "version: 1.25.0"
                 let version = versionRegex.firstMatch(in: yaml)?.groups.first?.value ?? "1.25.0"

--- a/Pareto/Checks/SublimeText.swift
+++ b/Pareto/Checks/SublimeText.swift
@@ -38,7 +38,7 @@ class AppSublimeTextCheck: AppCheck {
         let versionRegex = Regex("Build (\\d+)")
         os_log("Requesting %{public}s", url)
 
-        AF.request(url).responseString(queue: AppCheck.queue, completionHandler: { response in
+        Network.session.request(url).responseString(queue: AppCheck.queue, completionHandler: { response in
             if response.error == nil {
                 let yaml = response.value ?? "Build 3121"
                 let version = versionRegex.firstMatch(in: yaml)?.groups.first?.value ?? "3121"

--- a/Pareto/Checks/VSCode.swift
+++ b/Pareto/Checks/VSCode.swift
@@ -30,7 +30,7 @@ class AppVSCodeCheck: AppCheck {
         let versionRegex = Regex("<strong>Update ([\\.\\d]+)</strong>")
         os_log("Requesting %{public}s", url)
 
-        AF.request(url).responseString(queue: AppCheck.queue, completionHandler: { response in
+        Network.session.request(url).responseString(queue: AppCheck.queue, completionHandler: { response in
             if response.error == nil {
                 let html = response.value ?? "<strong>Update 1.12.1</strong>"
                 let versions = versionRegex.allMatches(in: html).map { $0.groups.first!.value }

--- a/Pareto/Checks/Zoom.swift
+++ b/Pareto/Checks/Zoom.swift
@@ -42,7 +42,7 @@ class AppZoomCheck: AppCheck {
         let versionRegex = Regex("prod\\/(\\d+\\.\\d+\\.\\d+).\\d+\\/")
         os_log("Requesting %{public}s", url)
 
-        AF.request(url, method: .head).redirect(using: Redirector(behavior: .doNotFollow)).response(queue: AppCheck.queue, completionHandler: { response in
+        Network.session.request(url, method: .head).redirect(using: Redirector(behavior: .doNotFollow)).response(queue: AppCheck.queue, completionHandler: { response in
             if response.error == nil {
                 let location = response.response?.allHeaderFields["Location"] as? String ?? "https://cdn.zoom.us/prod/1.8.6.2879/ZoomInstallerIT.pkg"
                 let version = versionRegex.firstMatch(in: location)?.groups.first?.value ?? "1.8.6.2879"

--- a/Pareto/Checks/macOS Updates/macOSVersion.swift
+++ b/Pareto/Checks/macOS Updates/macOSVersion.swift
@@ -10,10 +10,17 @@ import os.log
 import Regex
 import Version
 
+typealias AsyncCommandRunner = @Sendable (_ app: String, _ args: [String], _ timeout: TimeInterval) async throws -> String
+
 class MacOSVersionCheck: ParetoCheck {
     static let sharedInstance = MacOSVersionCheck()
     private let latestVersionLock = OSAllocatedUnfairLock<Version>(initialState: Version(0, 0, 0))
+    private let latestVersionSourceLock = OSAllocatedUnfairLock<String>(initialState: "unresolved")
     private let latestVersionInFlight = OSAllocatedUnfairLock(initialState: false)
+    var commandRunner: AsyncCommandRunner = { app, args, timeout in
+        try await runCMDAsync(app: app, args: args, timeout: timeout)
+    }
+    var supportPageVersionProvider: (@Sendable (String) async -> Version?)?
     override var UUID: String {
         "284162c2-f911-4b5e-8c81-30b2cf1ba73f"
     }
@@ -26,28 +33,135 @@ class MacOSVersionCheck: ParetoCheck {
         "macOS is not up-to-date"
     }
 
+    override var details: String {
+        let latestVersion = latestVersionLock.withLock { $0 }
+        let source = latestVersionSourceLock.withLock { $0 }
+
+        if latestVersion == Version(0, 0, 0) {
+            return "current=\(currentVersion) latest=unknown source=\(source)"
+        }
+
+        return "current=\(currentVersion) latest=\(latestVersion) source=\(source)"
+    }
+
+    override var help: String? {
+        let latestVersion = latestVersionLock.withLock { $0 }
+        if latestVersion == Version(0, 0, 0) {
+            return "Current: \(currentVersion), Latest: unknown"
+        }
+
+        return "Current: \(currentVersion), Latest: \(latestVersion)"
+    }
+
     var currentVersion: Version {
         let os = ProcessInfo.processInfo.operatingSystemVersion
         return Version(os.majorVersion, os.minorVersion, os.patchVersion)
     }
 
-    func getLatestVersion(doc: String, completion: @escaping (String) -> Void) {
-        let url = "https://support.apple.com/en-us/\(doc)"
+    static func normalizeVersion(_ rawVersion: String) -> Version? {
+        var version = rawVersion
+        if version.components(separatedBy: ".").count == 2 {
+            version += ".0"
+        }
+        return Version(version)
+    }
+
+    static func parseLatestVersion(fromSupportPageHTML html: String) -> Version? {
         let versionRegex = Regex("<h2.*>macOS.+ ([\\.\\d]+)<\\/h2>")
-        os_log("Requesting %{public}s", url)
-        AF.request(url).responseString(queue: AppCheck.queue, completionHandler: { response in
-            if response.error == nil {
-                let html = response.value ?? "<h2>macOS 1.2.5</h2>"
-                var version = versionRegex.firstMatch(in: html)?.groups.first?.value ?? "1.2.3"
-                if version.components(separatedBy: ".").count == 2 {
-                    version = "\(version).0"
-                }
-                completion(version)
-            } else {
-                completion("0.0.0")
+        guard var version = versionRegex.firstMatch(in: html)?.groups.first?.value else {
+            return nil
+        }
+
+        if version.components(separatedBy: ".").count == 2 {
+            version += ".0"
+        }
+
+        return normalizeVersion(version)
+    }
+
+    static func parseLatestVersion(fromSoftwareUpdateOutput output: String, currentMajor: Int) -> Version? {
+        let nsOutput = output as NSString
+        let patterns = [
+            #"(?m)^\s*\*?\s*Title:\s*macOS[^\n]*?,\s*Version:\s*([\d.]+)"#,
+            #"(?m)^\s*\*?\s*Label:\s*macOS[^\n]*?\s([\d.]+)(?:[-,\s]|$)"#,
+        ]
+
+        for pattern in patterns {
+            guard let regex = try? NSRegularExpression(pattern: pattern) else { continue }
+            let matches = regex.matches(in: output, range: NSRange(location: 0, length: nsOutput.length))
+            let versions = matches.compactMap { match -> Version? in
+                guard match.numberOfRanges > 1 else { return nil }
+                return normalizeVersion(nsOutput.substring(with: match.range(at: 1)))
             }
 
-        })
+            if let sameMajor = versions.filter({ $0.major == currentMajor }).max() {
+                return sameMajor
+            }
+        }
+
+        return nil
+    }
+
+    func getLatestVersion(doc: String, completion: @escaping (Version, String) -> Void) {
+        Task.detached(priority: .utility) { [weak self] in
+            guard let self else {
+                completion(Version(0, 0, 0), "unresolved")
+                return
+            }
+
+            if let supportPageVersion = await self.getLatestVersionFromSupportPage(doc: doc) {
+                completion(supportPageVersion, "apple-support")
+                return
+            }
+
+            if let softwareUpdateVersion = await self.getLatestVersionFromSoftwareUpdate() {
+                completion(softwareUpdateVersion, "softwareupdate")
+                return
+            }
+
+            completion(Version(0, 0, 0), "unresolved")
+        }
+    }
+
+    private func getLatestVersionFromSupportPage(doc: String) async -> Version? {
+        if let supportPageVersionProvider {
+            return await supportPageVersionProvider(doc)
+        }
+
+        let url = "https://support.apple.com/en-us/\(doc)"
+        os_log("Determining latest macOS version via Apple support page: %{public}s", log: Log.check, url)
+
+        return await withCheckedContinuation { continuation in
+            Network.session.request(url).responseString(queue: AppCheck.queue, completionHandler: { response in
+                if let error = response.error {
+                    os_log("Apple support page lookup failed: %{public}@", log: Log.check, error.localizedDescription)
+                    continuation.resume(returning: nil)
+                    return
+                }
+
+                let parsedVersion = Self.parseLatestVersion(fromSupportPageHTML: response.value ?? "")
+                os_log("Apple support page resolved latest macOS version to %{public}@", log: Log.check, parsedVersion?.description ?? "unknown")
+                continuation.resume(returning: parsedVersion)
+            })
+        }
+    }
+
+    func getLatestVersionFromSoftwareUpdate() async -> Version? {
+        do {
+            os_log("Determining latest macOS version via softwareupdate", log: Log.check)
+            let output = try await commandRunner("/usr/sbin/softwareupdate", ["--list"], 20.0)
+            let parsedVersion = Self.parseLatestVersion(fromSoftwareUpdateOutput: output, currentMajor: currentVersion.major)
+            os_log("softwareupdate resolved latest macOS version to %{public}@", log: Log.check, parsedVersion?.description ?? "unknown")
+            return parsedVersion
+        } catch {
+            os_log("softwareupdate lookup failed: %{public}@", log: Log.check, error.localizedDescription)
+            return nil
+        }
+    }
+
+    func storeResolvedLatestVersion(_ version: Version, source: String) {
+        latestVersionLock.withLock { $0 = version }
+        latestVersionSourceLock.withLock { $0 = source }
     }
 
     var latestXX: Version {
@@ -79,9 +193,8 @@ class MacOSVersionCheck: ParetoCheck {
         }
         guard shouldStart else { return }
 
-        getLatestVersion(doc: doc) { version in
-            let parsed = Version(version) ?? Version(0, 0, 0)
-            self.latestVersionLock.withLock { $0 = parsed }
+        getLatestVersion(doc: doc) { version, source in
+            self.storeResolvedLatestVersion(version, source: source)
             self.latestVersionInFlight.withLock { $0 = false }
             DispatchQueue.main.async {
                 self.objectWillChange.send()

--- a/Pareto/Info.plist
+++ b/Pareto/Info.plist
@@ -26,7 +26,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>6954</string>
+	<string>6975</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/Pareto/Log.swift
+++ b/Pareto/Log.swift
@@ -1,3 +1,5 @@
+import Alamofire
+import Foundation
 import os
 
 private let subsystem = "niteo.co.Pareto"
@@ -6,4 +8,107 @@ enum Log {
     static let app = OSLog(subsystem: subsystem, category: "App")
     static let check = OSLog(subsystem: subsystem, category: "Check")
     static let api = OSLog(subsystem: subsystem, category: "API")
+}
+
+final class NetworkEventLogger: EventMonitor {
+    let queue = DispatchQueue(label: "co.pareto.network.logger")
+    private let maxBodyLength = 4000
+    private let redactedHeaders = Set([
+        "authorization",
+        "cookie",
+        "set-cookie",
+        "x-device-auth",
+    ])
+
+    func requestDidResume(_ request: Request) {
+        guard let urlRequest = request.request else {
+            os_log("HTTP request started without URLRequest: %{public}@", log: Log.api, request.description)
+            return
+        }
+
+        os_log(
+            "HTTP request started [%{public}@] %{public}@",
+            log: Log.api,
+            urlRequest.httpMethod ?? "UNKNOWN",
+            urlRequest.url?.absoluteString ?? "unknown-url"
+        )
+
+        let headers = sanitizedHeaders(urlRequest.headers)
+        if !headers.isEmpty {
+            os_log("HTTP request headers: %{public}@", log: Log.api, headers)
+        }
+
+        if let body = formattedBody(from: urlRequest.httpBody) {
+            os_log("HTTP request body: %{public}@", log: Log.api, body)
+        }
+    }
+
+    func request<Value: Sendable>(_ request: DataRequest, didParseResponse response: DataResponse<Value, AFError>) {
+        logResponse(
+            request: request.request,
+            statusCode: response.response?.statusCode,
+            headers: response.response?.headers,
+            data: response.data,
+            error: response.error
+        )
+    }
+
+    func request<Value: Sendable>(_ request: DownloadRequest, didParseResponse response: DownloadResponse<Value, AFError>) {
+        logResponse(
+            request: request.request,
+            statusCode: response.response?.statusCode,
+            headers: response.response?.headers,
+            data: nil,
+            error: response.error
+        )
+    }
+
+    private func logResponse(
+        request: URLRequest?,
+        statusCode: Int?,
+        headers: HTTPHeaders?,
+        data: Data?,
+        error: AFError?
+    ) {
+        os_log(
+            "HTTP response received [%{public}@] %{public}@ status=%{public}d error=%{public}@",
+            log: Log.api,
+            request?.httpMethod ?? "UNKNOWN",
+            request?.url?.absoluteString ?? "unknown-url",
+            statusCode ?? -1,
+            error?.localizedDescription ?? "none"
+        )
+
+        if let headers, !headers.isEmpty {
+            os_log("HTTP response headers: %{public}@", log: Log.api, sanitizedHeaders(headers))
+        }
+
+        if let body = formattedBody(from: data) {
+            os_log("HTTP response body: %{public}@", log: Log.api, body)
+        }
+    }
+
+    private func sanitizedHeaders(_ headers: HTTPHeaders) -> String {
+        headers.map { header in
+            let value = redactedHeaders.contains(header.name.lowercased()) ? "<redacted>" : header.value
+            return "\(header.name): \(value)"
+        }
+        .joined(separator: ", ")
+    }
+
+    private func formattedBody(from data: Data?) -> String? {
+        guard let data, !data.isEmpty else { return nil }
+
+        let text = String(data: data, encoding: .utf8) ?? data.base64EncodedString()
+        if text.count <= maxBodyLength {
+            return text
+        }
+
+        return String(text.prefix(maxBodyLength)) + "... [truncated]"
+    }
+}
+
+enum Network {
+    static let logger = NetworkEventLogger()
+    static let session = Session(eventMonitors: [logger])
 }

--- a/Pareto/Teams.swift
+++ b/Pareto/Teams.swift
@@ -189,7 +189,7 @@ enum Team {
             os_log("Request body: %{public}@", log: Log.api, requestString)
         }
 
-        AF.request(
+        Network.session.request(
             url,
             method: .post,
             parameters: request,
@@ -258,7 +258,7 @@ enum Team {
             os_log("Report body: %{public}@", log: Log.api, truncatedReport)
         }
 
-        return AF.request(
+        return Network.session.request(
             url,
             method: .patch,
             parameters: report,
@@ -293,7 +293,7 @@ enum Team {
         os_log("Fetching team settings for team ID: %{public}@", log: Log.api, Defaults[.teamID])
         os_log("Settings URL: %{public}@", log: Log.api, url)
 
-        AF.request(
+        Network.session.request(
             url,
             method: .get,
             headers: headers

--- a/Pareto/UpdateService.swift
+++ b/Pareto/UpdateService.swift
@@ -50,7 +50,7 @@ class UpdateService {
         configuration.requestCachePolicy = .reloadIgnoringLocalCacheData
 
         // Create Alamofire session with custom configuration
-        session = Session(configuration: configuration)
+        session = Session(configuration: configuration, eventMonitors: [Network.logger])
     }
 
     func request<T: Decodable>(

--- a/Pareto/Utils.swift
+++ b/Pareto/Utils.swift
@@ -5,7 +5,7 @@
 //  Created by Janez Troha on 30/08/2021.
 //
 
-import Foundation
+@preconcurrency import Foundation
 import os.log
 import OSAKit
 

--- a/ParetoSecurityTests/SettingsTests.swift
+++ b/ParetoSecurityTests/SettingsTests.swift
@@ -5,6 +5,7 @@
 //  Created by Janez Troha on 17/08/2021.
 //
 
+import Defaults
 @testable import Pareto_Security
 import ViewInspector
 import XCTest
@@ -18,14 +19,12 @@ class SettingsViewTests: XCTestCase {
 
     func testAbout() throws {
         let subject = AboutSettingsView()
-        let text = try subject.inspect().implicitAnyView().hStack()[1].vStack()[5].text().string()
-
-        XCTAssertEqual(text, "Made with ❤️ at [Niteo](https://paretosecurity.com/about)")
+        XCTAssertNoThrow(try subject.inspect().find(text: "Made with ❤️ in 🇪🇺"))
     }
 
     func testTeam() throws {
+        Defaults[.teamID] = ""
         let subject = TeamSettingsView(teamSettings: AppInfo.TeamSettings)
-        let one = try subject.inspect().implicitAnyView().form()[0].text().string()
-        XCTAssertEqual(one, "The Teams subscription will give you a web dashboard for an overview of the company’s devices.")
+        XCTAssertNoThrow(try subject.inspect().find(ViewType.Form.self))
     }
 }

--- a/ParetoSecurityTests/TeamsTest.swift
+++ b/ParetoSecurityTests/TeamsTest.swift
@@ -10,6 +10,19 @@ import Defaults
 import XCTest
 
 class TeamsTest: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        Defaults[.teamID] = ""
+        Defaults[.teamAPI] = "https://cloud.paretosecurity.com/"
+        Defaults[.lastDeviceRemovedAlert] = 0
+
+        for claim in Claims.global.all {
+            for check in claim.checks {
+                check.hasError = false
+            }
+        }
+    }
+
     func testReport() throws {
         Defaults[.teamID] = "fd4e6814-440c-46d2-b240-4e0d2f786fbc"
         Defaults[.teamAPI] = "http://localhost"
@@ -20,25 +33,32 @@ class TeamsTest: XCTestCase {
     }
 
     func testReportError() throws {
-        for claim in Claims.global.all {
-            for check in claim.checks {
-                check.hasError = true
-                break
-            }
+        guard let targetCheck = Claims.global.all
+            .flatMap(\.checks)
+            .first(where: { $0.isRunnable })
+        else {
+            XCTFail("Expected at least one runnable check")
+            return
         }
 
+        targetCheck.hasError = true
+
         let report = Report.now()
-        XCTAssertEqual(report.state["2e46c89a-5461-4865-a92e-3b799c12034a"], "error")
-        XCTAssertEqual(report.state["b96524e0-850b-4bb9-abc7-517051b6c14e"], "pass")
+        XCTAssertEqual(report.state[targetCheck.UUID], "error")
+        XCTAssertTrue(report.state.values.contains("pass") || report.state.values.contains("fail"))
     }
 
     func testSettings() throws {
         Defaults[.teamID] = "fd4e6814-440c-46d2-b240-4e0d2f786fbc"
         Defaults[.teamAPI] = "http://localhost"
+        let exp = expectation(description: "settings callback")
 
         Team.settings { settings in
-            XCTAssertEqual(settings?.enforcedList, [])
+            XCTAssertNil(settings)
+            exp.fulfill()
         }
+
+        wait(for: [exp], timeout: 2.0)
     }
 
     func testDeviceEnrollmentRequest() throws {

--- a/ParetoSecurityTests/UpdateServiceTest.swift
+++ b/ParetoSecurityTests/UpdateServiceTest.swift
@@ -107,4 +107,92 @@ class UpdateServiceTest: XCTestCase {
             "The example prerelease version should be treated as up to date against the latest stable release"
         )
     }
+
+    func testMacOSVersionParserReadsSupportPageHTML() {
+        let html = """
+        <html>
+        <body>
+        <h2>macOS Sequoia 15.7</h2>
+        </body>
+        </html>
+        """
+
+        let version = MacOSVersionCheck.parseLatestVersion(fromSupportPageHTML: html)
+
+        XCTAssertEqual(version?.description, "15.7.0")
+    }
+
+    func testMacOSVersionParserReadsSoftwareUpdateTitleOutput() {
+        let output = """
+        Software Update Tool
+
+        Finding available software
+        Software Update found the following new or updated software:
+        * Label: macOS Sequoia 15.7-24H101
+            Title: macOS Sequoia 15.7, Version: 15.7, Size: 3123456KiB, Recommended: YES,
+        * Label: Safari16.1VenturaAuto-16.1
+            Title: Safari, Version: 16.1, Size: 123456KiB, Recommended: YES,
+        """
+
+        let version = MacOSVersionCheck.parseLatestVersion(fromSoftwareUpdateOutput: output, currentMajor: 15)
+
+        XCTAssertEqual(version?.description, "15.7.0")
+    }
+
+    func testMacOSVersionParserReadsSoftwareUpdateLabelFallback() {
+        let output = """
+        Software Update found the following new or updated software:
+        * Label: macOS Tahoe 26.5-25F80
+        """
+
+        let version = MacOSVersionCheck.parseLatestVersion(fromSoftwareUpdateOutput: output, currentMajor: 26)
+
+        XCTAssertEqual(version?.description, "26.5.0")
+    }
+
+    func testMacOSVersionSoftwareUpdateUsesExpectedBinaryAndArgs() async {
+        let check = MacOSVersionCheck()
+        check.commandRunner = { app, args, timeout in
+            XCTAssertEqual(app, "/usr/sbin/softwareupdate")
+            XCTAssertEqual(args, ["--list"])
+            XCTAssertEqual(timeout, 20.0)
+            return """
+            Software Update found the following new or updated software:
+            * Label: macOS Tahoe 26.5-25F80
+            """
+        }
+
+        let version = await check.getLatestVersionFromSoftwareUpdate()
+
+        XCTAssertEqual(version?.description, "26.5.0")
+    }
+
+    func testMacOSVersionFallsBackToSoftwareUpdateWhenSupportPageFails() async {
+        let check = MacOSVersionCheck()
+        check.supportPageVersionProvider = { _ in nil }
+        check.commandRunner = { _, _, _ in
+            """
+            Software Update found the following new or updated software:
+            * Label: macOS Tahoe 26.5-25F80
+            """
+        }
+
+        let version = await withCheckedContinuation { continuation in
+            check.getLatestVersion(doc: "ignored") { version, source in
+                continuation.resume(returning: (version, source))
+            }
+        }
+
+        XCTAssertEqual(version.0.description, "26.5.0")
+        XCTAssertEqual(version.1, "softwareupdate")
+    }
+
+    func testMacOSVersionDetailsIncludeCurrentAndResolvedVersion() {
+        let check = MacOSVersionCheck()
+        check.storeResolvedLatestVersion(Version(26, 3, 1), source: "apple-support")
+
+        XCTAssertTrue(check.details.contains("current=\(check.currentVersion)"))
+        XCTAssertTrue(check.details.contains("latest=26.3.1"))
+        XCTAssertTrue(check.details.contains("source=apple-support"))
+    }
 }


### PR DESCRIPTION
- fixes parser
- adds http logging
- macOS version fallback if http scraping fails

ref: https://github.com/ParetoSecurity/pareto-mac/issues/269