### PR TITLE
fix: Allow patch drift

### DIFF
--- a/Pareto/Checks/macOS Updates/macOSVersion.swift
+++ b/Pareto/Checks/macOS Updates/macOSVersion.swift
@@ -102,6 +102,16 @@ class MacOSVersionCheck: ParetoCheck {
         return nil
     }
 
+    static func isCurrentVersionUpToDate(current: Version, latest: Version) -> Bool {
+        // Special case: macOS 26.3.2 is only offered to MacBook Neo devices, but this check
+        // compares against Apple's global latest version and would otherwise warn all 26.3.1 Macs.
+        if current == Version(26, 3, 1), latest == Version(26, 3, 2) {
+            return true
+        }
+
+        return current >= latest
+    }
+
     func getLatestVersion(doc: String, completion: @escaping (Version, String) -> Void) {
         Task.detached(priority: .utility) { [weak self] in
             guard let self else {
@@ -203,6 +213,6 @@ class MacOSVersionCheck: ParetoCheck {
     }
 
     override func checkPasses() -> Bool {
-        return currentVersion >= latestXX
+        return Self.isCurrentVersionUpToDate(current: currentVersion, latest: latestXX)
     }
 }

--- a/ParetoSecurityTests/UpdateServiceTest.swift
+++ b/ParetoSecurityTests/UpdateServiceTest.swift
@@ -195,4 +195,13 @@ class UpdateServiceTest: XCTestCase {
         XCTAssertTrue(check.details.contains("latest=26.3.1"))
         XCTAssertTrue(check.details.contains("source=apple-support"))
     }
+
+    func testMacOSVersionTreatsMacBookNeoPatchLagAsUpToDate() {
+        XCTAssertTrue(
+            MacOSVersionCheck.isCurrentVersionUpToDate(
+                current: Version(26, 3, 1),
+                latest: Version(26, 3, 2)
+            )
+        )
+    }
 }


### PR DESCRIPTION
Special case: macOS 26.3.2 is only offered to MacBook Neo devices, but macOS check
compares against Apple's global latest version and would otherwise warn all 26.3.1 Macs.

ref: https://github.com/ParetoSecurity/pareto-mac/issues/269