### PR TITLE
fix: Handle package manager config

### DIFF
--- a/Pareto/Checks/System Integrity/PackageManagerSupplyChain.swift
+++ b/Pareto/Checks/System Integrity/PackageManagerSupplyChain.swift
@@ -12,15 +12,18 @@ class PackageManagerSupplyChainCheck: ParetoCheck {
 
     let homeDirectory: URL
     let installedBinaries: Set<String>?
+    let packageManagerVersions: [String: String]
     let environment: [String: String]
 
     init(
         homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser,
         installedBinaries: Set<String>? = nil,
+        packageManagerVersions: [String: String] = [:],
         environment: [String: String] = ProcessInfo.processInfo.environment
     ) {
         self.homeDirectory = homeDirectory
         self.installedBinaries = installedBinaries
+        self.packageManagerVersions = packageManagerVersions
         self.environment = environment
     }
 
@@ -62,21 +65,20 @@ class PackageManagerSupplyChainCheck: ParetoCheck {
 
     func validationFailures() -> [String] {
         let npmrc = homeDirectory.appendingPathComponent(".npmrc")
-        let pnpm = pnpmConfigPath()
         let bunfig = homeDirectory.appendingPathComponent(".bunfig.toml")
         let uv = homeDirectory.appendingPathComponent(".config/uv/uv.toml")
         let pypirc = homeDirectory.appendingPathComponent(".pypirc")
         var failures: [String] = []
 
         if let contents = readFile(npmrc) {
-            failures.append(contentsOf: Self.validateNpmrc(contents))
+            failures.append(contentsOf: validateNpmConfig(contents))
         } else if isBinaryInstalled("npm") || isBinaryInstalled("yarn") {
             failures.append("~/.npmrc is missing")
         }
-        if let contents = readFile(pnpm) {
-            failures.append(contentsOf: Self.validatePnpmConfig(contents, displayPath: pnpmConfigDisplayPath()))
+        if let pnpmConfig = activePnpmConfig() {
+            failures.append(contentsOf: Self.validatePnpmConfig(pnpmConfig.contents, displayPath: pnpmConfig.displayPath))
         } else if isBinaryInstalled("pnpm") {
-            failures.append("\(pnpmConfigDisplayPath()) is missing")
+            failures.append(pnpmConfigMissingDetail())
         }
         if let contents = readFile(bunfig) {
             failures.append(contentsOf: Self.validateBunfig(contents))
@@ -98,11 +100,11 @@ class PackageManagerSupplyChainCheck: ParetoCheck {
     private func passingDetails() -> String {
         var details: [String] = []
 
-        if let contents = readFile(homeDirectory.appendingPathComponent(".npmrc")), Self.validateNpmrc(contents).isEmpty {
+        if let contents = readFile(homeDirectory.appendingPathComponent(".npmrc")), validateNpmConfig(contents).isEmpty {
             details.append("~/.npmrc delays npm-compatible package releases and pins exact versions")
         }
-        if let contents = readFile(pnpmConfigPath()), Self.validatePnpmConfig(contents, displayPath: pnpmConfigDisplayPath()).isEmpty {
-            details.append("\(pnpmConfigDisplayPath()) delays pnpm package releases")
+        if let pnpmConfig = activePnpmConfig(), Self.validatePnpmConfig(pnpmConfig.contents, displayPath: pnpmConfig.displayPath).isEmpty {
+            details.append("\(pnpmConfig.displayPath) delays pnpm package releases")
         }
         if let contents = readFile(homeDirectory.appendingPathComponent(".bunfig.toml")), Self.validateBunfig(contents).isEmpty {
             details.append("~/.bunfig.toml delays Bun package releases")
@@ -123,11 +125,10 @@ class PackageManagerSupplyChainCheck: ParetoCheck {
     private func hasPackageManagerConfigOrBinary() -> Bool {
         let configFiles = [
             homeDirectory.appendingPathComponent(".npmrc"),
-            pnpmConfigPath(),
             homeDirectory.appendingPathComponent(".bunfig.toml"),
             homeDirectory.appendingPathComponent(".config/uv/uv.toml"),
             homeDirectory.appendingPathComponent(".pypirc"),
-        ]
+        ] + pnpmConfigPaths().map(\.url)
         if configFiles.contains(where: { FileManager.default.fileExists(atPath: $0.path) }) {
             return true
         }
@@ -138,8 +139,37 @@ class PackageManagerSupplyChainCheck: ParetoCheck {
         if let installedBinaries {
             return installedBinaries.contains(name)
         }
-        let output = runCMD(app: "/usr/bin/which", args: [name]).trimmingCharacters(in: .whitespacesAndNewlines)
-        return !output.isEmpty
+        return executablePath(for: name) != nil
+    }
+
+    private func packageManagerVersion(_ name: String) -> String? {
+        if let version = packageManagerVersions[name] {
+            return version.isEmpty ? nil : version
+        }
+        guard let path = executablePath(for: name) else { return nil }
+        let output = runCMD(app: path, args: ["--version"]).trimmingCharacters(in: .whitespacesAndNewlines)
+        return output.isEmpty ? nil : output
+    }
+
+    private func executablePath(for name: String) -> String? {
+        let path = runCMD(app: "/usr/bin/which", args: [name]).trimmingCharacters(in: .whitespacesAndNewlines)
+        return Self.executablePath(fromWhichOutput: path)
+    }
+
+    static func executablePath(fromWhichOutput output: String) -> String? {
+        let path = output.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard (path as NSString).isAbsolutePath else { return nil }
+        guard FileManager.default.isExecutableFile(atPath: path) else { return nil }
+        return path
+    }
+
+    private func activePnpmConfig() -> (contents: String, displayPath: String)? {
+        for configPath in pnpmConfigPaths() {
+            if let contents = readFile(configPath.url) {
+                return (contents, configPath.displayPath)
+            }
+        }
+        return nil
     }
 
     private func readFile(_ url: URL) -> String? {
@@ -147,18 +177,25 @@ class PackageManagerSupplyChainCheck: ParetoCheck {
         return try? String(contentsOf: url, encoding: .utf8)
     }
 
-    private func pnpmConfigPath() -> URL {
+    private func pnpmConfigPaths() -> [(url: URL, displayPath: String)] {
         if let xdgConfigHome = xdgConfigHome() {
-            return URL(fileURLWithPath: xdgConfigHome).appendingPathComponent("pnpm/config.yaml")
+            let xdgDirectory = URL(fileURLWithPath: xdgConfigHome)
+            return [
+                (xdgDirectory.appendingPathComponent("pnpm/rc"), "$XDG_CONFIG_HOME/pnpm/rc"),
+                (xdgDirectory.appendingPathComponent("pnpm/config.yaml"), "$XDG_CONFIG_HOME/pnpm/config.yaml"),
+            ]
         }
-        return homeDirectory.appendingPathComponent("Library/Preferences/pnpm/config.yaml")
+        return [
+            (homeDirectory.appendingPathComponent("Library/Preferences/pnpm/rc"), "~/Library/Preferences/pnpm/rc"),
+            (homeDirectory.appendingPathComponent("Library/Preferences/pnpm/config.yaml"), "~/Library/Preferences/pnpm/config.yaml"),
+            (homeDirectory.appendingPathComponent(".config/pnpm/rc"), "~/.config/pnpm/rc"),
+            (homeDirectory.appendingPathComponent(".config/pnpm/config.yaml"), "~/.config/pnpm/config.yaml"),
+        ]
     }
 
-    private func pnpmConfigDisplayPath() -> String {
-        if xdgConfigHome() != nil {
-            return "$XDG_CONFIG_HOME/pnpm/config.yaml"
-        }
-        return "~/Library/Preferences/pnpm/config.yaml"
+    private func pnpmConfigMissingDetail() -> String {
+        let paths = pnpmConfigPaths().map(\.displayPath).joined(separator: ", ")
+        return "pnpm config is missing (checked \(paths))"
     }
 
     private func xdgConfigHome() -> String? {
@@ -171,21 +208,62 @@ class PackageManagerSupplyChainCheck: ParetoCheck {
         return (xdgConfigHome as NSString).standardizingPath
     }
 
+    private func validateNpmConfig(_ contents: String) -> [String] {
+        var failures = Self.validateNpmrc(contents)
+        guard failures.isEmpty, isBinaryInstalled("npm"), Self.npmConfigUsesMinReleaseAge(contents) else {
+            return failures
+        }
+        guard let version = packageManagerVersion("npm") else {
+            failures.append("npm version could not be determined, so ~/.npmrc min-release-age could not be verified")
+            return failures
+        }
+        if !Self.isVersion(version, atLeast: "11.14.0") {
+            failures.append("npm is older than 11.14.0 and does not enforce ~/.npmrc min-release-age")
+        }
+        return failures
+    }
+
+    private static func npmConfigUsesMinReleaseAge(_ contents: String) -> Bool {
+        return keyValuePairs(contents)["min-release-age"] != nil
+    }
+
     static func validateNpmrc(_ contents: String) -> [String] {
         let values = keyValuePairs(contents)
         var failures: [String] = []
 
-        if integerValue(values["min-release-age"]) ?? 0 < 7 {
-            failures.append("~/.npmrc min-release-age is below 7 days")
-        }
-        if integerValue(values["minimum-release-age"]) ?? 0 < 10080 {
-            failures.append("~/.npmrc minimum-release-age is below 10080 minutes")
+        let minReleaseAgeDays = integerValue(values["min-release-age"]) ?? 0
+        let minimumReleaseAgeMinutes = integerValue(values["minimum-release-age"]) ?? 0
+        if minReleaseAgeDays < 7, minimumReleaseAgeMinutes < 10080 {
+            failures.append("~/.npmrc release age is below 7 days; set either min-release-age >= 7 or minimum-release-age >= 10080")
         }
         if values["save-exact"]?.lowercased() != "true" {
             failures.append("~/.npmrc save-exact is not enabled")
         }
 
         return failures
+    }
+
+    static func isVersion(_ version: String?, atLeast minimumVersion: String) -> Bool {
+        guard let version else { return false }
+        if version.contains("-") {
+            return false
+        }
+        let current = versionComponents(version)
+        let minimum = versionComponents(minimumVersion)
+        for index in 0..<max(current.count, minimum.count) {
+            let currentPart = index < current.count ? current[index] : 0
+            let minimumPart = index < minimum.count ? minimum[index] : 0
+            if currentPart != minimumPart {
+                return currentPart > minimumPart
+            }
+        }
+        return true
+    }
+
+    private static func versionComponents(_ version: String) -> [Int] {
+        return version.trimmingCharacters(in: CharacterSet(charactersIn: "vV")).split(separator: ".").map { part in
+            Int(part.prefix { $0.isNumber }) ?? 0
+        }
     }
 
     static func validatePnpmConfig(_ contents: String, displayPath: String) -> [String] {

--- a/Pareto/Info.plist
+++ b/Pareto/Info.plist
@@ -26,7 +26,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>6994</string>
+	<string>7004</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/ParetoSecurityTests/ParetoSecurityTests.swift
+++ b/ParetoSecurityTests/ParetoSecurityTests.swift
@@ -70,7 +70,7 @@ class ParetoSecurityTests: XCTestCase {
 
         XCTAssertTrue(check.isRunnable)
         XCTAssertFalse(check.checkPasses())
-        XCTAssertEqual(check.details, "- ~/Library/Preferences/pnpm/config.yaml is missing")
+        XCTAssertEqual(check.details, "- pnpm config is missing (checked ~/Library/Preferences/pnpm/rc, ~/Library/Preferences/pnpm/config.yaml, ~/.config/pnpm/rc, ~/.config/pnpm/config.yaml)")
     }
 
     func testPackageManagerSupplyChainPassesWithProtectedConfigs() throws {
@@ -82,9 +82,9 @@ class ParetoSecurityTests: XCTestCase {
         defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
 
         try """
-        min-release-age=7
-        minimum-release-age=10080
-        save-exact=true
+        # npm accepts standard ini comments
+        min-release-age=7 # trailing comment
+        save-exact=true ; trailing comment
         """.write(to: temporaryDirectory.appendingPathComponent(".npmrc"), atomically: true, encoding: .utf8)
         try """
         minimumReleaseAge: 10080
@@ -139,8 +139,148 @@ class ParetoSecurityTests: XCTestCase {
         let failures = check.validationFailures()
 
         XCTAssertFalse(check.checkPasses())
-        XCTAssertEqual(failures.count, 6)
+        XCTAssertEqual(failures.count, 5)
         XCTAssertTrue(failures.contains("~/Library/Preferences/pnpm/config.yaml minimumReleaseAge is below 10080 minutes"))
+    }
+
+    func testPackageManagerSupplyChainPassesWithMinimumReleaseAgeOnly() throws {
+        let temporaryDirectory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: temporaryDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
+
+        try """
+        minimum-release-age=10080
+        save-exact=true
+        """.write(to: temporaryDirectory.appendingPathComponent(".npmrc"), atomically: true, encoding: .utf8)
+
+        let check = PackageManagerSupplyChainCheck(homeDirectory: temporaryDirectory, installedBinaries: [])
+
+        XCTAssertTrue(check.checkPasses())
+        XCTAssertEqual(check.details, "- ~/.npmrc delays npm-compatible package releases and pins exact versions")
+    }
+
+    func testPackageManagerSupplyChainPassesWithMinimumReleaseAgeOnlyAndOldNpm() throws {
+        let temporaryDirectory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: temporaryDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
+
+        try """
+        minimum-release-age=10080
+        save-exact=true
+        """.write(to: temporaryDirectory.appendingPathComponent(".npmrc"), atomically: true, encoding: .utf8)
+
+        let check = PackageManagerSupplyChainCheck(
+            homeDirectory: temporaryDirectory,
+            installedBinaries: ["npm"],
+            packageManagerVersions: ["npm": "11.13.0"]
+        )
+
+        XCTAssertTrue(check.checkPasses())
+        XCTAssertEqual(check.details, "- ~/.npmrc delays npm-compatible package releases and pins exact versions")
+    }
+
+    func testPackageManagerSupplyChainFailsWithUnsupportedNpmVersion() throws {
+        let temporaryDirectory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: temporaryDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
+
+        try """
+        min-release-age=7
+        save-exact=true
+        """.write(to: temporaryDirectory.appendingPathComponent(".npmrc"), atomically: true, encoding: .utf8)
+
+        let check = PackageManagerSupplyChainCheck(
+            homeDirectory: temporaryDirectory,
+            installedBinaries: ["npm"],
+            packageManagerVersions: ["npm": "11.13.0"]
+        )
+
+        XCTAssertFalse(check.checkPasses())
+        XCTAssertEqual(check.details, "- npm is older than 11.14.0 and does not enforce ~/.npmrc min-release-age")
+    }
+
+    func testPackageManagerSupplyChainFailsWithPrereleaseNpmVersion() throws {
+        let temporaryDirectory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: temporaryDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
+
+        try """
+        min-release-age=7
+        save-exact=true
+        """.write(to: temporaryDirectory.appendingPathComponent(".npmrc"), atomically: true, encoding: .utf8)
+
+        let check = PackageManagerSupplyChainCheck(
+            homeDirectory: temporaryDirectory,
+            installedBinaries: ["npm"],
+            packageManagerVersions: ["npm": "11.14.0-rc.1"]
+        )
+
+        XCTAssertFalse(check.checkPasses())
+        XCTAssertEqual(check.details, "- npm is older than 11.14.0 and does not enforce ~/.npmrc min-release-age")
+    }
+
+    func testPackageManagerSupplyChainPassesWithSupportedNpmVersion() throws {
+        let temporaryDirectory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: temporaryDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
+
+        try """
+        min-release-age=7
+        save-exact=true
+        """.write(to: temporaryDirectory.appendingPathComponent(".npmrc"), atomically: true, encoding: .utf8)
+
+        let check = PackageManagerSupplyChainCheck(
+            homeDirectory: temporaryDirectory,
+            installedBinaries: ["npm"],
+            packageManagerVersions: ["npm": "11.14.0"]
+        )
+
+        XCTAssertTrue(check.checkPasses())
+        XCTAssertEqual(check.details, "- ~/.npmrc delays npm-compatible package releases and pins exact versions")
+    }
+
+    func testPackageManagerSupplyChainFailsWithUnknownNpmVersion() throws {
+        let temporaryDirectory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: temporaryDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
+
+        try """
+        min-release-age=7
+        save-exact=true
+        """.write(to: temporaryDirectory.appendingPathComponent(".npmrc"), atomically: true, encoding: .utf8)
+
+        let check = PackageManagerSupplyChainCheck(
+            homeDirectory: temporaryDirectory,
+            installedBinaries: ["npm"],
+            packageManagerVersions: ["npm": ""]
+        )
+
+        XCTAssertFalse(check.checkPasses())
+        XCTAssertEqual(check.details, "- npm version could not be determined, so ~/.npmrc min-release-age could not be verified")
+    }
+
+    func testPackageManagerSupplyChainComparesNpmVersions() {
+        XCTAssertFalse(PackageManagerSupplyChainCheck.isVersion(nil, atLeast: "11.14.0"))
+        XCTAssertFalse(PackageManagerSupplyChainCheck.isVersion("", atLeast: "11.14.0"))
+        XCTAssertFalse(PackageManagerSupplyChainCheck.isVersion("11.13.0", atLeast: "11.14.0"))
+        XCTAssertFalse(PackageManagerSupplyChainCheck.isVersion("11.14.0-rc.1", atLeast: "11.14.0"))
+        XCTAssertTrue(PackageManagerSupplyChainCheck.isVersion("11.14.0", atLeast: "11.14.0"))
+        XCTAssertTrue(PackageManagerSupplyChainCheck.isVersion("v11.14.0", atLeast: "11.14.0"))
+        XCTAssertTrue(PackageManagerSupplyChainCheck.isVersion("12", atLeast: "11.14.0"))
+    }
+
+    func testPackageManagerSupplyChainValidatesWhichOutput() throws {
+        let temporaryDirectory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let executable = temporaryDirectory.appendingPathComponent("npm")
+        try FileManager.default.createDirectory(at: temporaryDirectory, withIntermediateDirectories: true)
+        try "".write(to: executable, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: executable.path)
+        defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
+
+        XCTAssertEqual(PackageManagerSupplyChainCheck.executablePath(fromWhichOutput: executable.path), executable.path)
+        XCTAssertNil(PackageManagerSupplyChainCheck.executablePath(fromWhichOutput: "npm not found"))
+        XCTAssertNil(PackageManagerSupplyChainCheck.executablePath(fromWhichOutput: "npm"))
+        XCTAssertNil(PackageManagerSupplyChainCheck.executablePath(fromWhichOutput: temporaryDirectory.appendingPathComponent("missing").path))
     }
 
     func testPackageManagerSupplyChainUsesPnpmXDGConfigHome() throws {
@@ -151,7 +291,7 @@ class ParetoSecurityTests: XCTestCase {
         defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
 
         try """
-        minimum-release-age: 10080
+        minimumReleaseAge: 10080
         """.write(to: pnpmDirectory.appendingPathComponent("config.yaml"), atomically: true, encoding: .utf8)
 
         let check = PackageManagerSupplyChainCheck(
@@ -162,6 +302,84 @@ class ParetoSecurityTests: XCTestCase {
 
         XCTAssertTrue(check.checkPasses())
         XCTAssertEqual(check.details, "- $XDG_CONFIG_HOME/pnpm/config.yaml delays pnpm package releases")
+    }
+
+    func testPackageManagerSupplyChainUsesDarwinPnpmConfigHomeYamlFallback() throws {
+        let temporaryDirectory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let pnpmDirectory = temporaryDirectory.appendingPathComponent(".config/pnpm")
+        try FileManager.default.createDirectory(at: pnpmDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
+
+        try """
+        minimumReleaseAge: 10080
+        """.write(to: pnpmDirectory.appendingPathComponent("config.yaml"), atomically: true, encoding: .utf8)
+
+        let check = PackageManagerSupplyChainCheck(homeDirectory: temporaryDirectory, installedBinaries: ["pnpm"])
+
+        XCTAssertTrue(check.checkPasses())
+        XCTAssertEqual(check.details, "- ~/.config/pnpm/config.yaml delays pnpm package releases")
+    }
+
+    func testPackageManagerSupplyChainUsesPnpmXDGConfigHomeRc() throws {
+        let temporaryDirectory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let xdgDirectory = temporaryDirectory.appendingPathComponent("xdg")
+        let pnpmDirectory = xdgDirectory.appendingPathComponent("pnpm")
+        try FileManager.default.createDirectory(at: pnpmDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
+
+        try """
+        ; pnpm 10 writes rc-style config
+        minimum-release-age=10080 # trailing comment
+        """.write(to: pnpmDirectory.appendingPathComponent("rc"), atomically: true, encoding: .utf8)
+
+        let check = PackageManagerSupplyChainCheck(
+            homeDirectory: temporaryDirectory,
+            installedBinaries: ["pnpm"],
+            environment: ["XDG_CONFIG_HOME": xdgDirectory.path]
+        )
+
+        XCTAssertTrue(check.checkPasses())
+        XCTAssertEqual(check.details, "- $XDG_CONFIG_HOME/pnpm/rc delays pnpm package releases")
+    }
+
+    func testPackageManagerSupplyChainUsesActivePnpmConfig() throws {
+        let temporaryDirectory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let xdgDirectory = temporaryDirectory.appendingPathComponent("xdg")
+        let pnpmDirectory = xdgDirectory.appendingPathComponent("pnpm")
+        try FileManager.default.createDirectory(at: pnpmDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
+
+        try """
+        minimumReleaseAge: 10079
+        """.write(to: pnpmDirectory.appendingPathComponent("config.yaml"), atomically: true, encoding: .utf8)
+        try """
+        minimum-release-age=10080
+        """.write(to: pnpmDirectory.appendingPathComponent("rc"), atomically: true, encoding: .utf8)
+
+        let check = PackageManagerSupplyChainCheck(
+            homeDirectory: temporaryDirectory,
+            installedBinaries: ["pnpm"],
+            environment: ["XDG_CONFIG_HOME": xdgDirectory.path]
+        )
+
+        XCTAssertTrue(check.checkPasses())
+        XCTAssertEqual(check.details, "- $XDG_CONFIG_HOME/pnpm/rc delays pnpm package releases")
+    }
+
+    func testPackageManagerSupplyChainUsesDarwinPnpmConfigHomeRc() throws {
+        let temporaryDirectory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let pnpmDirectory = temporaryDirectory.appendingPathComponent(".config/pnpm")
+        try FileManager.default.createDirectory(at: pnpmDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
+
+        try """
+        minimum-release-age=10080
+        """.write(to: pnpmDirectory.appendingPathComponent("rc"), atomically: true, encoding: .utf8)
+
+        let check = PackageManagerSupplyChainCheck(homeDirectory: temporaryDirectory, installedBinaries: ["pnpm"])
+
+        XCTAssertTrue(check.checkPasses())
+        XCTAssertEqual(check.details, "- ~/.config/pnpm/rc delays pnpm package releases")
     }
 
     func testPackageManagerSupplyChainAcceptsTopLevelUvExcludeNewer() throws {


### PR DESCRIPTION

- Native npm versions before 11.14.0 do not enforce `min-release-age`, so the check now warns/fails even when `.npmrc` looks valid.
- `.npmrc` accepts either `min-release-age=7` or `minimum-release-age=10080` for compatibility.
- pnpm now checks `rc` and `config.yaml`, prefers the active `rc` path, and handles `#` / `;` comments.

Refs https://github.com/teamniteo/pareto/issues/855