### PR TITLE
fix: Restrict linkDevice host override to pre-release

### DIFF
--- a/Pareto/AppHandlers.swift
+++ b/Pareto/AppHandlers.swift
@@ -809,11 +809,12 @@ class AppHandlers: NSObject, ObservableObject, NetworkHandlerObserver {
                 let inviteID = url.queryParams()["invite_id"] ?? ""
                 let host = url.queryParams()["host"] ?? ""
 
-                // Set teamAPI based on host parameter
-                if host.isEmpty {
-                    Defaults[.teamAPI] = "https://cloud.paretosecurity.com"
-                } else {
+                // host is untrusted input from an external URL; only honor it in pre-release builds.
+                // https://github.com/teamniteo/pareto/issues/863
+                if !host.isEmpty, Defaults.betaChannelComputed {
                     Defaults[.teamAPI] = host
+                } else {
+                    Defaults[.teamAPI] = "https://cloud.paretosecurity.com"
                 }
 
                 if inviteID.isEmpty {


### PR DESCRIPTION
paretosecurity://linkDevice accepted an arbitrary host query
parameter and persisted it as the team API endpoint with no
validation, in every build. A crafted link could redirect device
enrollment and report traffic to an attacker-controlled server.

Only honor the host override when pre-release/beta is enabled;
otherwise always use the production cloud API.

Refs https://github.com/teamniteo/pareto/issues/863