### PR TITLE
fix: don't cache a failed system_profiler lookup forever

### DIFF
--- a/Pareto/AppInfo.swift
+++ b/Pareto/AppInfo.swift
@@ -38,8 +38,14 @@ struct SPHardware: Codable {
     }
 
     static func gather() -> SPHardware? {
-        guard let jsonData = runCMD(app: "/usr/sbin/system_profiler", args: ["SPHardwareDataType", "-json"]).data(using: .utf8) else { return nil }
-        let info: SPHardwareWrapper = try! JSONDecoder().decode(SPHardwareWrapper.self, from: jsonData)
+        // stderr is kept off the pipe, otherwise a warning from system_profiler
+        // ends up mixed into stdout and the JSON no longer parses.
+        let output = runCMD(app: "/usr/sbin/system_profiler", args: ["SPHardwareDataType", "-json"], mergeStderr: false)
+        guard let jsonData = output.data(using: .utf8) else { return nil }
+        guard let info = try? JSONDecoder().decode(SPHardwareWrapper.self, from: jsonData) else {
+            os_log("Failed to decode SPHardwareDataType output", log: Log.app, type: .error)
+            return nil
+        }
         return info.spHardwareDataType.first
     }
 }
@@ -56,8 +62,28 @@ enum AppInfo {
 
     static var secExp = false
     static let Flags = FlagsUpdater()
-    static let HWInfo = SPHardware.gather()
     static let TeamSettings = TeamSettingsUpdater()
+
+    private static let hwInfoLock = NSLock()
+    private static var hwInfoCache: SPHardware?
+
+    /// Hardware info from system_profiler, memoized on success only.
+    ///
+    /// A failed lookup is deliberately not cached: system_profiler can come back
+    /// empty under load (notably right after login, when every launch item starts
+    /// at once). Caching that would pin the app to "Unknown" for the rest of the
+    /// process lifetime, which for a menu bar app means days or weeks.
+    static var HWInfo: SPHardware? {
+        hwInfoLock.lock()
+        defer { hwInfoLock.unlock() }
+
+        if let cached = hwInfoCache {
+            return cached
+        }
+        hwInfoCache = SPHardware.gather()
+        return hwInfoCache
+    }
+
     static var utmSource: String {
         var source = "app"
 
@@ -93,15 +119,18 @@ enum AppInfo {
         transformer: TransformerFactory.forCodable(ofType: Version.self) // Storage<String, Version>
     )
 
-    static var hwModelName: String {
-        if let modelNumber = HWInfo?.modelNumber {
-            return "\(HWInfo?.machineName ?? "Unknown") (\(modelNumber))"
-        }
-        return "\(HWInfo?.machineName ?? "Unknown") (\(HWInfo?.machineModel ?? "Unknown"))"
+    /// Model as "<machine name> (<model number>)", or nil when the lookup failed.
+    static var hwModelName: String? {
+        guard let info = HWInfo else { return nil }
+
+        let number = info.modelNumber ?? info.machineModel
+        guard let name = info.machineName else { return number }
+        guard let number else { return name }
+        return "\(name) (\(number))"
     }
 
-    static var hwSerial: String {
-        HWInfo?.serialNumber ?? "Unknown"
+    static var hwSerial: String? {
+        HWInfo?.serialNumber
     }
 
     static let teamsURL = { () -> URL in
@@ -158,7 +187,7 @@ enum AppInfo {
     }
 
     static let getVersions = { () -> String in
-        "HW: \(AppInfo.hwModelName) macOS: \(AppInfo.macOSVersionString) App: Pareto Auditor App Version: \(AppInfo.appVersion) Build: \(AppInfo.buildVersion)"
+        "HW: \(AppInfo.hwModelName ?? "Unknown") macOS: \(AppInfo.macOSVersionString) App: Pareto Auditor App Version: \(AppInfo.appVersion) Build: \(AppInfo.buildVersion)"
     }
 
     static func getSystemUUID() -> String? {

--- a/Pareto/Teams.swift
+++ b/Pareto/Teams.swift
@@ -61,8 +61,10 @@ struct ReportingDevice: Encodable {
     let machineUUID: String
     let machineName: String
     let macOSVersion: String
-    let modelName: String
-    let modelSerial: String
+    // Optional so a failed hardware lookup omits the keys entirely rather than
+    // reporting "Unknown" as if it were a real model name.
+    let modelName: String?
+    let modelSerial: String?
 
     static func current() -> ReportingDevice {
         let reason = "Disabled"

--- a/Pareto/Utils.swift
+++ b/Pareto/Utils.swift
@@ -9,20 +9,23 @@ import Foundation
 import os.log
 import OSAKit
 
-func runCMD(app: String, args: [String]) -> String {
+/// Run a command and return its output.
+///
+/// `mergeStderr` defaults to true because most callers here parse tools that
+/// report on stderr. Pass false when the output has to parse cleanly, e.g. JSON.
+func runCMD(app: String, args: [String], mergeStderr: Bool = true) -> String {
     let task = Process()
     let pipe = Pipe()
 
     task.standardOutput = pipe
-    task.standardError = pipe
+    task.standardError = mergeStderr ? pipe : FileHandle.nullDevice
     task.arguments = args
     task.launchPath = app
     task.launch()
     task.waitUntilExit()
 
     let data = pipe.fileHandleForReading.readDataToEndOfFile()
-    let output = String(data: data, encoding: .utf8)!
-    return output
+    return String(data: data, encoding: .utf8) ?? ""
 }
 
 func runShell(args: [String]) -> String {


### PR DESCRIPTION
Fixes devices reporting their hardware inventory as the literal strings `Unknown (Unknown)` (model) and `Unknown` (serial), instead of the real values, with the setting enabled.

## The bug

`AppInfo.HWInfo` was a `static let`:

```swift
static let HWInfo = SPHardware.gather()   // lazy, evaluated ONCE, never recomputed
static var hwModelName: String { "\(HWInfo?.machineName ?? "Unknown") (\(...  ?? "Unknown"))" }
static var hwSerial: String { HWInfo?.serialNumber ?? "Unknown" }
```

Swift initializes `static let` lazily via `swift_once` and never recomputes it. The only readers are `ReportingDevice.current()`, so `HWInfo` is initialized on the **first report the app ever sends**. `gather()` shells out to `system_profiler` and returns `.first`, which is `nil` when the array comes back empty — and then `hwModelName` formats to exactly `"Unknown (Unknown)"` and `hwSerial` to `"Unknown"`.

Because the failure is cached, the app keeps reporting those for the **entire process lifetime**. For a menu bar app that runs for days or weeks, the only recovery is quitting and relaunching.

Consistent with what we see in practice: it is sticky per device, uncorrelated with macOS version, app version or hardware model, and model and serial always fail together (both derive from this one optional). `system_profiler` is most likely to return empty under the resource contention right after login, when every launch item starts at once.

## Changes

- **Memoize on success only.** A `nil` result is no longer cached, so the next report retries instead of being pinned for the process lifetime. This alone fixes the bug.
- **Replace `try!` on the JSON decode**, which *crashed the app* on malformed output, with a soft failure that gets retried and logged.
- **Keep stderr off the stdout pipe when gathering.** `runCMD` merges stderr into stdout, so any `system_profiler` warning corrupted the JSON. This is now opt-in via a new `mergeStderr` parameter that **defaults to the existing behaviour**, leaving the other 24 call sites byte-for-byte unchanged — many of them parse tools that report on stderr.
- **Omit inventory keys instead of sending sentinels.** `modelName`/`modelSerial` are now optional, so a failed lookup drops the keys rather than reporting `"Unknown"` as if it were real data. Synthesized `Encodable` uses `encodeIfPresent`, so no `null` is emitted — which matters, because the API schema types both as non-nullable strings and would reject a null.
- Partial data degrades gracefully (falls back to `machine_model`, then to whichever field exists) instead of collapsing to `Unknown (Unknown)`.

**Format for healthy devices is unchanged.**

## Verification

I don't have Xcode locally (Command Line Tools only), so **I could not run `make build` or `make test` — CI needs to be the gate on the full compile.**

What I did verify:

- `swiftc -parse` clean on all three edited files
- `swiftc -typecheck` on the extracted `runCMD`, confirming the `Pipe`/`FileHandle` ternary resolves against `standardError`'s `Any?` contextual type
- Ported the accessor logic into a standalone harness and ran it — 17 assertions covering: failure retried and never cached (5 accesses → 5 attempts), success memoized (no repeated subprocess spawning), recovery after a transient failure without restart, unchanged format for healthy devices, graceful partial-data fallbacks, and `nil` inventory omitting the keys with no `null` in the payload
- Confirmed the real `system_profiler` output shape on a current macOS release matches the decoder

## Not addressed

`runCMD` still calls `waitUntilExit()` with no timeout, so a hung `system_profiler` blocks the reporting thread. It also uses the deprecated non-throwing `task.launch()`, and reads a single pipe after waiting, which can deadlock if a command ever exceeds the 64KB pipe buffer. All pre-existing and shared by 24 call sites — worth a separate PR rather than widening this one.
