### PR TITLE
fix: Never report placeholder hardware inventory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ xcuserdata/
 *.zip
 junit.xml
 .claude/settings.local.json
+.cachebro

--- a/Pareto/AppHandlers.swift
+++ b/Pareto/AppHandlers.swift
@@ -207,6 +207,9 @@ class AppHandlers: NSObject, ObservableObject, NetworkHandlerObserver {
         // invalidate possible expired cache
         try? AppInfo.versionStorage.removeExpiredObjects()
 
+        // Gather hardware info while the checks run, so it is ready at report time
+        AppInfo.warmHWInfo()
+
         // Snooze in effect
         if Defaults[.snoozeTime] >= Date().currentTimeMs() {
             os_log("Checks are snoozed until %{public}ld", log: Log.app, Defaults[.snoozeTime])

--- a/Pareto/AppInfo.swift
+++ b/Pareto/AppInfo.swift
@@ -116,9 +116,9 @@ enum AppInfo {
         return "\(name) (\(model))"
     }
 
-    static var hwSerial: String? {
-        HWInfo?.serialNumber ?? ioPlatformString(kIOPlatformSerialNumberKey)
-    }
+static var hwSerial: String? {
+    HWInfo?.serialNumber ?? ioPlatformString(kIOPlatformSerialNumberKey as String)
+}
 
     // A failed lookup is never cached, so the next report retries instead of
     // reporting placeholders for the rest of the process lifetime.

--- a/Pareto/AppInfo.swift
+++ b/Pareto/AppInfo.swift
@@ -37,12 +37,6 @@ struct SPHardware: Codable {
         case serialNumber = "serial_number"
     }
 
-    static func gather() -> SPHardware? {
-        guard let jsonData = runCMD(app: "/usr/sbin/system_profiler", args: ["SPHardwareDataType", "-json"]).data(using: .utf8) else { return nil }
-        let info: SPHardwareWrapper = try! JSONDecoder().decode(SPHardwareWrapper.self, from: jsonData)
-        return info.spHardwareDataType.first
-    }
-
     static func gatherAsync() async -> SPHardware? {
         do {
             let output = try await runCMDAsync(app: "/usr/sbin/system_profiler", args: ["SPHardwareDataType", "-json"], timeout: 20.0)
@@ -59,7 +53,7 @@ struct SPHardware: Codable {
 enum AppInfo {
     static let appVersion: String = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as! String
     static let buildVersion: String = Bundle.main.infoDictionary?["CFBundleVersion"] as! String
-    static var machineName: String { Host.current().localizedName! }
+    static var machineName: String { Host.current().localizedName ?? ProcessInfo.processInfo.hostName }
     static let macOSVersion = ProcessInfo.processInfo.operatingSystemVersion
     static let macOSVersionString = "\(macOSVersion.majorVersion).\(macOSVersion.minorVersion).\(macOSVersion.patchVersion)"
     static var isRunningTests: Bool {
@@ -69,11 +63,14 @@ enum AppInfo {
     static var secExp = false
     static let Flags = FlagsUpdater()
     private static let hwInfoLock = OSAllocatedUnfairLock<SPHardware?>(initialState: nil)
-    private static let hwInfoLoadStarted = OSAllocatedUnfairLock(initialState: false)
+    private static let hwInfoLoading = OSAllocatedUnfairLock(initialState: false)
 
     static var HWInfo: SPHardware? {
+        if let cached = hwInfoLock.withLock({ $0 }) {
+            return cached
+        }
         warmHWInfo()
-        return hwInfoLock.withLock { $0 }
+        return nil
     }
     static let TeamSettings = TeamSettingsUpdater()
     static var utmSource: String {
@@ -111,28 +108,37 @@ enum AppInfo {
         transformer: TransformerFactory.forCodable(ofType: Version.self) // Storage<String, Version>
     )
 
-    static var hwModelName: String {
-        if let modelNumber = HWInfo?.modelNumber {
-            return "\(HWInfo?.machineName ?? "Unknown") (\(modelNumber))"
-        }
-        return "\(HWInfo?.machineName ?? "Unknown") (\(HWInfo?.machineModel ?? "Unknown"))"
+    static var hwModelName: String? {
+        guard let info = HWInfo else { return nil }
+        let model = info.modelNumber ?? info.machineModel
+        guard let name = info.machineName else { return model }
+        guard let model else { return name }
+        return "\(name) (\(model))"
     }
 
-    static var hwSerial: String {
-        HWInfo?.serialNumber ?? "Unknown"
+    static var hwSerial: String? {
+        HWInfo?.serialNumber ?? ioPlatformString(kIOPlatformSerialNumberKey)
     }
 
+    // A failed lookup is never cached, so the next report retries instead of
+    // reporting placeholders for the rest of the process lifetime.
+    // https://github.com/teamniteo/pareto/issues/866
     static func warmHWInfo() {
-        let shouldStart = hwInfoLoadStarted.withLock { started in
-            if started { return false }
-            started = true
+        let shouldStart = hwInfoLoading.withLock { loading in
+            if loading { return false }
+            loading = true
             return true
         }
         guard shouldStart else { return }
 
         Task.detached(priority: .utility) {
             let info = await SPHardware.gatherAsync()
-            hwInfoLock.withLock { $0 = info }
+            if let info {
+                hwInfoLock.withLock { $0 = info }
+            } else {
+                os_log("Failed to gather hardware info", log: Log.app, type: .error)
+            }
+            hwInfoLoading.withLock { $0 = false }
         }
     }
 
@@ -190,14 +196,21 @@ enum AppInfo {
     }
 
     static let getVersions = { () -> String in
-        "HW: \(AppInfo.hwModelName) macOS: \(AppInfo.macOSVersionString) App: Pareto Auditor App Version: \(AppInfo.appVersion) Build: \(AppInfo.buildVersion)"
+        "HW: \(AppInfo.hwModelName ?? "Unknown") macOS: \(AppInfo.macOSVersionString) App: Pareto Auditor App Version: \(AppInfo.appVersion) Build: \(AppInfo.buildVersion)"
     }
 
     static func getSystemUUID() -> String? {
+        ioPlatformString(kIOPlatformUUIDKey)
+    }
+
+    private static func ioPlatformString(_ key: String) -> String? {
         let dev = IOServiceMatching("IOPlatformExpertDevice")
         let platformExpert: io_service_t = IOServiceGetMatchingService(kIOMainPortDefault, dev)
-        let serialNumberAsCFString = IORegistryEntryCreateCFProperty(platformExpert, kIOPlatformUUIDKey as CFString, kCFAllocatorDefault, 0)
-        IOObjectRelease(platformExpert)
-        return serialNumberAsCFString!.takeUnretainedValue() as? String
+        guard platformExpert != 0 else { return nil }
+        defer { IOObjectRelease(platformExpert) }
+        guard let property = IORegistryEntryCreateCFProperty(platformExpert, key as CFString, kCFAllocatorDefault, 0) else {
+            return nil
+        }
+        return property.takeUnretainedValue() as? String
     }
 }

--- a/Pareto/Teams.swift
+++ b/Pareto/Teams.swift
@@ -61,9 +61,12 @@ struct ReportingDevice: Encodable {
     let machineUUID: String
     let machineName: String
     let macOSVersion: String
-    let modelName: String
-    let modelSerial: String
+    let modelName: String?
+    let modelSerial: String?
 
+    // Fields are omitted when the hardware lookup failed, so Cloud never stores
+    // a placeholder as if it were real inventory data.
+    // https://github.com/teamniteo/pareto/issues/866
     static func current() -> ReportingDevice {
         let reason = "Disabled"
 

--- a/Pareto/Utils.swift
+++ b/Pareto/Utils.swift
@@ -120,11 +120,15 @@ func runCMD(app: String, args: [String]) -> String {
     task.standardError = pipe
     task.arguments = args
     task.launchPath = app
-    task.launch()
+    do {
+        try task.run()
+    } catch {
+        os_log("Failed to launch %{public}@: %{public}@", log: Log.app, app, error.localizedDescription)
+        return ""
+    }
     let data = pipe.fileHandleForReading.readDataToEndOfFile()
     task.waitUntilExit()
-    let output = String(data: data, encoding: .utf8)!
-    return output
+    return String(data: data, encoding: .utf8) ?? ""
 }
 
 func runShell(args: [String]) -> String {
@@ -139,8 +143,7 @@ func runShell(args: [String]) -> String {
         try task.run()
         let data = pipe.fileHandleForReading.readDataToEndOfFile()
         task.waitUntilExit()
-        let output = String(data: data, encoding: .utf8)!
-        return output
+        return String(data: data, encoding: .utf8) ?? ""
     } catch {
         return error.localizedDescription
     }

--- a/ParetoSecurityTests/TeamsTest.swift
+++ b/ParetoSecurityTests/TeamsTest.swift
@@ -79,6 +79,37 @@ class TeamsTest: XCTestCase {
         XCTAssertNotNil(json["device"])
     }
 
+    func testDeviceEnrollmentRequestOmitsUnknownHardware() throws {
+        let testDevice = ReportingDevice(
+            machineUUID: "test-uuid",
+            machineName: "Test Machine",
+            macOSVersion: "14.0",
+            modelName: nil,
+            modelSerial: nil
+        )
+        let data = try JSONEncoder().encode(testDevice)
+        let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+
+        XCTAssertNil(json["modelName"])
+        XCTAssertNil(json["modelSerial"])
+    }
+
+    func testSerialFallsBackToIOKit() throws {
+        XCTAssertNotNil(AppInfo.hwSerial)
+    }
+
+    func testHardwareInfoResolvesAfterWarm() async throws {
+        AppInfo.warmHWInfo()
+
+        for _ in 0 ..< 60 where AppInfo.HWInfo == nil {
+            try await Task.sleep(nanoseconds: 500_000_000)
+            AppInfo.warmHWInfo()
+        }
+
+        XCTAssertNotNil(AppInfo.HWInfo)
+        XCTAssertNotNil(AppInfo.hwModelName)
+    }
+
     func testDeviceEnrollmentResponse() throws {
         let json = """
         {


### PR DESCRIPTION
A failed system_profiler lookup was cached for the process lifetime, so
one transient failure made the app report "Unknown (Unknown)" and
"Unknown" on every subsequent report until relaunch (~17% of Macs).

Only memoize the lookup on success, so a later report retries, and omit
modelName/modelSerial entirely when the lookup fails instead of sending
sentinels that Cloud stores as real inventory data. The serial now falls
back to IOKit (IOPlatformSerialNumber), which needs no subprocess.

Also:
- warm hardware info when checks start, so it is ready at report time
- remove unused SPHardware.gather(), whose try! crashed on stderr noise
- stop force-unwrapping process output and Host.current().localizedName
- launch runCMD via try task.run() instead of deprecated launch()

Refs #866