### PR TITLE
fix: Accept explicit save-exact=false in ~/.npmrc

### DIFF
--- a/Pareto/Checks/System Integrity/PackageManagerSupplyChain.swift
+++ b/Pareto/Checks/System Integrity/PackageManagerSupplyChain.swift
@@ -101,7 +101,7 @@ class PackageManagerSupplyChainCheck: ParetoCheck {
         var details: [String] = []
 
         if let contents = readFile(homeDirectory.appendingPathComponent(".npmrc")), validateNpmConfig(contents).isEmpty {
-            details.append("~/.npmrc delays npm-compatible package releases and pins exact versions")
+            details.append("~/.npmrc delays npm-compatible package releases")
         }
         if let pnpmConfig = activePnpmConfig(), Self.validatePnpmConfig(pnpmConfig.contents, displayPath: pnpmConfig.displayPath).isEmpty {
             details.append("\(pnpmConfig.displayPath) delays pnpm package releases")
@@ -278,8 +278,10 @@ class PackageManagerSupplyChainCheck: ParetoCheck {
         if minReleaseAgeDays < 7, minimumReleaseAgeMinutes < 10080 {
             failures.append("~/.npmrc release age is below 7 days; set either min-release-age >= 7 or minimum-release-age >= 10080")
         }
-        if values["save-exact"]?.lowercased() != "true" {
-            failures.append("~/.npmrc save-exact is not enabled")
+        // An explicit save-exact=false is an informed choice, so only an
+        // unset value fails. https://github.com/ParetoSecurity/pareto-mac/issues/303
+        if values["save-exact"] == nil {
+            failures.append("~/.npmrc save-exact is not set; set it to true or false")
         }
 
         return failures

--- a/Pareto/Info.plist
+++ b/Pareto/Info.plist
@@ -26,7 +26,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>7017</string>
+	<string>7019</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/ParetoSecurityTests/ParetoSecurityTests.swift
+++ b/ParetoSecurityTests/ParetoSecurityTests.swift
@@ -117,7 +117,7 @@ class ParetoSecurityTests: XCTestCase {
 
         XCTAssertTrue(check.checkPasses())
         XCTAssertEqual(check.details, """
-        - ~/.npmrc delays npm-compatible package releases and pins exact versions
+        - ~/.npmrc delays npm-compatible package releases
         - ~/Library/Preferences/pnpm/config.yaml delays pnpm package releases
         - ~/.bunfig.toml delays Bun package releases
         - ~/.config/uv/uv.toml excludes Python packages newer than 7 days
@@ -154,8 +154,39 @@ class ParetoSecurityTests: XCTestCase {
         let failures = check.validationFailures()
 
         XCTAssertFalse(check.checkPasses())
-        XCTAssertEqual(failures.count, 5)
+        XCTAssertEqual(failures.count, 4)
         XCTAssertTrue(failures.contains("~/Library/Preferences/pnpm/config.yaml minimumReleaseAge is below 10080 minutes"))
+    }
+
+    func testPackageManagerSupplyChainPassesWithExplicitSaveExactFalse() throws {
+        let temporaryDirectory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: temporaryDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
+
+        try """
+        min-release-age=7
+        save-exact=false
+        """.write(to: temporaryDirectory.appendingPathComponent(".npmrc"), atomically: true, encoding: .utf8)
+
+        let check = PackageManagerSupplyChainCheck(homeDirectory: temporaryDirectory, installedBinaries: [])
+
+        XCTAssertTrue(check.checkPasses())
+        XCTAssertEqual(check.details, "- ~/.npmrc delays npm-compatible package releases")
+    }
+
+    func testPackageManagerSupplyChainFailsWithoutSaveExact() throws {
+        let temporaryDirectory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: temporaryDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
+
+        try """
+        min-release-age=7
+        """.write(to: temporaryDirectory.appendingPathComponent(".npmrc"), atomically: true, encoding: .utf8)
+
+        let check = PackageManagerSupplyChainCheck(homeDirectory: temporaryDirectory, installedBinaries: [])
+
+        XCTAssertFalse(check.checkPasses())
+        XCTAssertEqual(check.details, "- ~/.npmrc save-exact is not set; set it to true or false")
     }
 
     func testPackageManagerSupplyChainPassesWithMinimumReleaseAgeOnly() throws {
@@ -171,7 +202,7 @@ class ParetoSecurityTests: XCTestCase {
         let check = PackageManagerSupplyChainCheck(homeDirectory: temporaryDirectory, installedBinaries: [])
 
         XCTAssertTrue(check.checkPasses())
-        XCTAssertEqual(check.details, "- ~/.npmrc delays npm-compatible package releases and pins exact versions")
+        XCTAssertEqual(check.details, "- ~/.npmrc delays npm-compatible package releases")
     }
 
     func testPackageManagerSupplyChainPassesWithMinimumReleaseAgeOnlyAndOldNpm() throws {
@@ -191,7 +222,7 @@ class ParetoSecurityTests: XCTestCase {
         )
 
         XCTAssertTrue(check.checkPasses())
-        XCTAssertEqual(check.details, "- ~/.npmrc delays npm-compatible package releases and pins exact versions")
+        XCTAssertEqual(check.details, "- ~/.npmrc delays npm-compatible package releases")
     }
 
     func testPackageManagerSupplyChainFailsWithUnsupportedNpmVersion() throws {
@@ -251,7 +282,7 @@ class ParetoSecurityTests: XCTestCase {
         )
 
         XCTAssertTrue(check.checkPasses())
-        XCTAssertEqual(check.details, "- ~/.npmrc delays npm-compatible package releases and pins exact versions")
+        XCTAssertEqual(check.details, "- ~/.npmrc delays npm-compatible package releases")
     }
 
     func testPackageManagerSupplyChainFailsWithUnknownNpmVersion() throws {


### PR DESCRIPTION
Requiring save-exact=true forced a package.json style on users who
already commit lock files. An explicit false is an informed choice and
now passes; only an unset save-exact fails.

Refs #303