### PR TITLE
ci: Simplify release workflow and harden code signing setup

### DIFF
--- a/.github/actions/notarize/action.yml
+++ b/.github/actions/notarize/action.yml
@@ -9,12 +9,18 @@ inputs:
     description: "Path to staple the ticket onto (defaults to submit-path)"
     required: false
     default: ""
+  staple-only:
+    description: "Skip submission and only staple (for targets covered by an earlier submission)"
+    required: false
+    default: "false"
   apple-id:
     description: "Apple ID used for notarization"
-    required: true
+    required: false
+    default: ""
   password:
     description: "App-specific password for the Apple ID"
-    required: true
+    required: false
+    default: ""
   team-id:
     description: "Apple Developer team identifier"
     required: false
@@ -24,6 +30,7 @@ runs:
   using: "composite"
   steps:
     - name: Submit for notarization
+      if: inputs.staple-only != 'true'
       shell: bash
       env:
         SUBMIT_PATH: ${{ inputs.submit-path }}

--- a/.github/actions/notarize/action.yml
+++ b/.github/actions/notarize/action.yml
@@ -1,0 +1,58 @@
+name: "Notarize"
+description: "Submit a build to Apple notarization and staple the ticket"
+
+inputs:
+  submit-path:
+    description: "File to submit to notarytool (.dmg, .zip or .pkg)"
+    required: true
+  staple-path:
+    description: "Path to staple the ticket onto (defaults to submit-path)"
+    required: false
+    default: ""
+  apple-id:
+    description: "Apple ID used for notarization"
+    required: true
+  password:
+    description: "App-specific password for the Apple ID"
+    required: true
+  team-id:
+    description: "Apple Developer team identifier"
+    required: false
+    default: "PM784W7B8X"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Submit for notarization
+      shell: bash
+      env:
+        SUBMIT_PATH: ${{ inputs.submit-path }}
+        NOTARIZATION_USERNAME: ${{ inputs.apple-id }}
+        NOTARIZATION_PASSWORD: ${{ inputs.password }}
+        TEAM_ID: ${{ inputs.team-id }}
+      run: |
+        xcrun notarytool submit "$SUBMIT_PATH" \
+          --apple-id "$NOTARIZATION_USERNAME" \
+          --password "$NOTARIZATION_PASSWORD" \
+          --team-id "$TEAM_ID" \
+          --progress \
+          --wait
+
+    # The ticket needs a moment to propagate to Apple's CDN after the
+    # submission is accepted, so retry a few times before giving up.
+    - name: Staple ticket
+      shell: bash
+      env:
+        SUBMIT_PATH: ${{ inputs.submit-path }}
+        STAPLE_PATH: ${{ inputs.staple-path }}
+      run: |
+        TARGET="${STAPLE_PATH:-$SUBMIT_PATH}"
+        for attempt in 1 2 3; do
+          if xcrun stapler staple "$TARGET"; then
+            exit 0
+          fi
+          echo "::warning::Stapling attempt $attempt failed, retrying in 15s"
+          sleep 15
+        done
+        echo "::error::Failed to staple notarization ticket onto $TARGET"
+        exit 1

--- a/.github/actions/publish-hashes/action.yml
+++ b/.github/actions/publish-hashes/action.yml
@@ -1,0 +1,28 @@
+name: "Publish Build Hashes"
+description: "Append MD5/SHA1/SHA256 digests of a built binary to the job summary"
+
+inputs:
+  title:
+    description: "Heading to use in the job summary"
+    required: true
+  binary:
+    description: "Path to the built executable"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Publish build hashes
+      shell: bash
+      env:
+        TITLE: ${{ inputs.title }}
+        BINARY: ${{ inputs.binary }}
+      run: |
+        {
+          echo "## $TITLE"
+          echo '```'
+          openssl dgst -md5 "$BINARY"
+          openssl dgst -sha1 "$BINARY"
+          openssl dgst -sha256 "$BINARY"
+          echo '```'
+        } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/actions/setup-build-env/action.yml
+++ b/.github/actions/setup-build-env/action.yml
@@ -46,3 +46,25 @@ runs:
         key: ${{ runner.os }}-spm-${{ hashFiles('Pareto Security.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
         restore-keys: |
           ${{ runner.os }}-spm-
+
+    # Content-addressed, so stale entries are never wrong — key on the commit
+    # to save fresh results every run and fall back to the newest cache.
+    - name: Cache compilation cache
+      uses: actions/cache@v6
+      with:
+        path: CompilationCache
+        key: ${{ runner.os }}-xcode${{ inputs.xcode-version }}-ccache-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-xcode${{ inputs.xcode-version }}-ccache-
+
+    # XCODE_XCCONFIG_FILE applies to every xcodebuild invocation, so all make
+    # targets get caching without Makefile changes.
+    - name: Enable Xcode compilation caching
+      shell: bash
+      run: |
+        {
+          echo "COMPILATION_CACHE_ENABLE_CACHING = YES"
+          echo "COMPILATION_CACHE_CAS_PATH = $GITHUB_WORKSPACE/CompilationCache"
+          echo "COMPILATION_CACHE_LIMIT_SIZE = 2G"
+        } > "$RUNNER_TEMP/compilation-cache.xcconfig"
+        echo "XCODE_XCCONFIG_FILE=$RUNNER_TEMP/compilation-cache.xcconfig" >> "$GITHUB_ENV"

--- a/.github/actions/setup-sentry-cli/action.yml
+++ b/.github/actions/setup-sentry-cli/action.yml
@@ -1,0 +1,15 @@
+name: "Setup Sentry CLI"
+description: "Install sentry-cli into the runner temp directory"
+
+runs:
+  using: "composite"
+  steps:
+    # The official installer is an order of magnitude faster than tapping
+    # getsentry/tools through Homebrew, and needs no sudo when INSTALL_DIR
+    # points somewhere writable.
+    - name: Install Sentry CLI
+      shell: bash
+      run: |
+        mkdir -p "$RUNNER_TEMP/bin"
+        curl -sSfL https://sentry.io/get-cli/ | INSTALL_DIR="$RUNNER_TEMP/bin" bash
+        echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"

--- a/.github/actions/setup-signing/action.yml
+++ b/.github/actions/setup-signing/action.yml
@@ -1,5 +1,5 @@
 name: "Setup Code Signing"
-description: "Import Apple certificates and configure keychain for code signing"
+description: "Import Apple certificates into a throwaway keychain and verify the signing identities"
 
 inputs:
   development-certificate:
@@ -26,83 +26,94 @@ inputs:
     description: "Passphrase for release certificate"
     required: false
     default: ""
-  keychain-password:
-    description: "Password for the temporary keychain"
-    required: false
-    default: ""
 
 outputs:
   signing-available:
     description: "true when certificates were imported, false when running unsigned"
-    value: ${{ steps.detect.outputs.available }}
+    value: ${{ steps.import.outputs.available }}
 
 runs:
   using: "composite"
   steps:
     # Pull requests from forks never receive repository secrets, so the
     # certificate inputs arrive empty. Detect that once and skip the import
-    # steps rather than failing the job on an undecodable empty .p12.
-    - name: Detect available certificates
-      id: detect
+    # rather than failing the job on an undecodable empty .p12.
+    #
+    # The keychain is created fresh per job and deleted at the end, so its
+    # password only has to be unguessable for the length of the run — there is
+    # nothing to gain from carrying it around as a repository secret.
+    - name: Import signing certificates
+      id: import
       shell: bash
       env:
         DEVELOPMENT_CERTIFICATE: ${{ inputs.development-certificate }}
+        DEVELOPMENT_PASSPHRASE: ${{ inputs.development-passphrase }}
+        APPLICATION_CERTIFICATE: ${{ inputs.application-certificate }}
+        APPLICATION_PASSPHRASE: ${{ inputs.application-passphrase }}
+        RELEASE_CERTIFICATE: ${{ inputs.release-certificate }}
+        RELEASE_PASSPHRASE: ${{ inputs.release-passphrase }}
       run: |
-        if [ -n "$DEVELOPMENT_CERTIFICATE" ]; then
-          echo "available=true" >> "$GITHUB_OUTPUT"
-        else
+        if [ -z "$DEVELOPMENT_CERTIFICATE$APPLICATION_CERTIFICATE$RELEASE_CERTIFICATE" ]; then
           echo "available=false" >> "$GITHUB_OUTPUT"
           echo "::notice::No signing certificates available, continuing unsigned."
+          exit 0
         fi
 
-    - name: Create keychain
-      if: steps.detect.outputs.available == 'true'
-      shell: bash
-      env:
-        KEYCHAIN_PASSWORD: ${{ inputs.keychain-password }}
-      run: |
         KEYCHAIN_PATH="$RUNNER_TEMP/app-signing.keychain-db"
+        KEYCHAIN_PASSWORD="$(uuidgen)"
 
-        # Create and configure keychain
-        security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH" 2>/dev/null || true
+        security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
         security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
         security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-        security list-keychain -d user -s "$KEYCHAIN_PATH"
+        # Keep the login keychain searchable so Apple's bundled intermediates
+        # stay visible to codesign.
+        security list-keychains -d user -s "$KEYCHAIN_PATH" login.keychain
+
+        import_cert() {
+          local name="$1" data="$2" passphrase="$3"
+          [ -n "$data" ] || return 0
+          local path="$RUNNER_TEMP/$name.p12"
+          if ! printf '%s' "$data" | base64 --decode > "$path"; then
+            echo "::error::$name certificate is not valid base64"
+            return 1
+          fi
+          # -T grants codesign access without a UI prompt; the partition list
+          # below is what actually silences the "user interaction is not
+          # allowed" failure on headless runners.
+          security import "$path" -P "$passphrase" -k "$KEYCHAIN_PATH" \
+            -f pkcs12 -A -T /usr/bin/codesign -T /usr/bin/productsign
+          rm -f "$path"
+        }
+
+        import_cert development "$DEVELOPMENT_CERTIFICATE" "$DEVELOPMENT_PASSPHRASE"
+        import_cert application "$APPLICATION_CERTIFICATE" "$APPLICATION_PASSPHRASE"
+        import_cert release "$RELEASE_CERTIFICATE" "$RELEASE_PASSPHRASE"
+
+        security set-key-partition-list -S apple-tool:,apple:,codesign: \
+          -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH" > /dev/null
 
         echo "KEYCHAIN_PATH=$KEYCHAIN_PATH" >> "$GITHUB_ENV"
+        echo "available=true" >> "$GITHUB_OUTPUT"
 
-    - name: Import Development Certificate
-      if: steps.detect.outputs.available == 'true'
+    # A .p12 exported without its issuing intermediate imports fine but is
+    # untrusted, so xcodebuild reports "No signing certificate ... found" only
+    # once it reaches -exportArchive, minutes into the job. Listing the usable
+    # identities here turns that into an immediate, readable failure.
+    - name: Verify signing identities
+      if: steps.import.outputs.available == 'true'
       shell: bash
-      env:
-        CERTIFICATE_DATA: ${{ inputs.development-certificate }}
-        CERTIFICATE_PASSPHRASE: ${{ inputs.development-passphrase }}
       run: |
-        CERT_PATH="$RUNNER_TEMP/development.p12"
-        echo -n "$CERTIFICATE_DATA" | base64 --decode > "$CERT_PATH"
-        security import "$CERT_PATH" -P "$CERTIFICATE_PASSPHRASE" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
-        rm -f "$CERT_PATH"
+        echo "Code signing identities in $KEYCHAIN_PATH:"
+        security find-identity -v -p codesigning "$KEYCHAIN_PATH"
 
-    - name: Import Developer ID Application Certificate
-      if: steps.detect.outputs.available == 'true' && inputs.application-certificate != ''
-      shell: bash
-      env:
-        CERTIFICATE_DATA: ${{ inputs.application-certificate }}
-        CERTIFICATE_PASSPHRASE: ${{ inputs.application-passphrase }}
-      run: |
-        CERT_PATH="$RUNNER_TEMP/application.p12"
-        echo -n "$CERTIFICATE_DATA" | base64 --decode > "$CERT_PATH"
-        security import "$CERT_PATH" -P "$CERTIFICATE_PASSPHRASE" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
-        rm -f "$CERT_PATH"
-
-    - name: Import Release Certificate
-      if: steps.detect.outputs.available == 'true' && inputs.release-certificate != ''
-      shell: bash
-      env:
-        CERTIFICATE_DATA: ${{ inputs.release-certificate }}
-        CERTIFICATE_PASSPHRASE: ${{ inputs.release-passphrase }}
-      run: |
-        CERT_PATH="$RUNNER_TEMP/release.p12"
-        echo -n "$CERTIFICATE_DATA" | base64 --decode > "$CERT_PATH"
-        security import "$CERT_PATH" -P "$CERTIFICATE_PASSPHRASE" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
-        rm -f "$CERT_PATH"
+        if ! security find-identity -v -p codesigning "$KEYCHAIN_PATH" | grep -q '^ *1)'; then
+          echo "::error::Certificates were imported but none form a valid code signing identity."
+          echo "::error::Usually the .p12 is expired, or was exported without its Apple intermediate certificate."
+          echo "Certificates present in the keychain:"
+          security find-certificate -a -p "$KEYCHAIN_PATH" | awk '
+            /BEGIN CERTIFICATE/ { pem = "" }
+            { pem = pem $0 "\n" }
+            /END CERTIFICATE/ { print pem | "openssl x509 -noout -subject -enddate"; close("openssl x509 -noout -subject -enddate") }
+          '
+          exit 1
+        fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,14 +24,9 @@ jobs:
     timeout-minutes: 45
     permissions:
       contents: write
-      deployments: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
-
-      - name: Get release tag
-        id: release
-        run: echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
 
       - name: Setup build environment
         uses: ./.github/actions/setup-build-env
@@ -47,96 +42,55 @@ jobs:
           application-passphrase: ${{ secrets.APPLICATION_CERTIFICATE_PASSPHRASE }}
           release-certificate: ${{ secrets.RELEASE_CERTIFICATE_DATA }}
           release-passphrase: ${{ secrets.RELEASE_CERTIFICATE_PASSPHRASE }}
-          keychain-password: ${{ secrets.KEYCHAIN_PASSWORD }}
 
       - name: Patch version from tag
         env:
-          VERSION: ${{ steps.release.outputs.tag }}
+          VERSION: ${{ github.ref_name }}
         run: |
           sed -E -i '' "s/MARKETING_VERSION = .*;/MARKETING_VERSION = ${VERSION};/g" "Pareto Security.xcodeproj/project.pbxproj"
 
       - name: Archive for distribution
         run: make archive-release
 
-      - name: Compress app
-        run: ditto -c -k --keepParent "Export/Pareto Security.app" ParetoSecurity.app.zip
-
-      - name: Upload app artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: ParetoSecurity.app
-          path: ParetoSecurity.app.zip
-          retention-days: 90
-
-      - name: Build DMG
-        run: npm install --global create-dmg && make dmg
-
-      - name: Notarize release build
-        env:
-          NOTARIZATION_PASSWORD: ${{ secrets.NOTARIZATION_PASSWORD }}
-          NOTARIZATION_USERNAME: ${{ secrets.NOTARIZATION_USERNAME }}
+      - name: Build release assets
         run: |
-          xcrun notarytool submit ParetoSecurity.dmg \
-            --password "$NOTARIZATION_PASSWORD" \
-            --apple-id "$NOTARIZATION_USERNAME" \
-            --team-id PM784W7B8X \
-            --progress \
-            --wait
-
-      - name: Upload DMG artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: ParetoSecurity.dmg
-          path: ParetoSecurity.dmg
-          retention-days: 90
-
-      - name: Staple DMG
-        run: |
-          for i in {1..3}; do
-            xcrun stapler staple ParetoSecurity.dmg && break || sleep 15
-          done
-
-      - name: Release DMG
-        uses: softprops/action-gh-release@v3
-        with:
-          files: ParetoSecurity.dmg
-
-      - name: Prepare app for release
-        run: |
-          rm -f ParetoSecurity.app.zip
+          npm install --global create-dmg
+          make dmg
           ditto -c -k --keepParent "Export/Pareto Security.app" ParetoSecurity.app.zip
+          "Export/Pareto Security.app/Contents/MacOS/Pareto Security" -export > checks.json
 
-      - name: Release app
-        uses: softprops/action-gh-release@v3
+      - name: Notarize DMG
+        uses: ./.github/actions/notarize
         with:
-          files: ParetoSecurity.app.zip
-
-      - name: Generate checks manifest
-        run: '"Export/Pareto Security.app/Contents/MacOS/Pareto Security" -export > checks.json'
-
-      - name: Release checks manifest
-        uses: softprops/action-gh-release@v3
-        with:
-          files: checks.json
+          submit-path: ParetoSecurity.dmg
+          apple-id: ${{ secrets.NOTARIZATION_USERNAME }}
+          password: ${{ secrets.NOTARIZATION_PASSWORD }}
 
       - name: Publish build hashes
-        run: |
-          {
-            echo "## Native Release"
-            echo '```'
-            openssl dgst -md5 "Export/Pareto Security.app/Contents/MacOS/Pareto Security"
-            openssl dgst -sha1 "Export/Pareto Security.app/Contents/MacOS/Pareto Security"
-            openssl dgst -sha256 "Export/Pareto Security.app/Contents/MacOS/Pareto Security"
-            echo '```'
-          } >> "$GITHUB_STEP_SUMMARY"
+        uses: ./.github/actions/publish-hashes
+        with:
+          title: Native Release
+          binary: Export/Pareto Security.app/Contents/MacOS/Pareto Security
 
-      - name: Install Sentry CLI
-        run: brew install getsentry/tools/sentry-cli
+      - name: Setup Sentry CLI
+        uses: ./.github/actions/setup-sentry-cli
 
       - name: Upload debug symbols
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: make sentry-debug-upload
+
+      # Single release call: every asset is built, notarized and stapled by
+      # now, so the release either gets the complete set or the job fails
+      # before publishing anything.
+      - name: Publish release
+        uses: softprops/action-gh-release@v3
+        with:
+          fail_on_unmatched_files: true
+          files: |
+            ParetoSecurity.dmg
+            ParetoSecurity.app.zip
+            checks.json
 
       - name: Cleanup keychain
         if: always()
@@ -146,16 +100,9 @@ jobs:
     name: Release SetApp
     runs-on: macos-latest
     timeout-minutes: 45
-    permissions:
-      contents: write
-      deployments: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
-
-      - name: Get release tag
-        id: release
-        run: echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
 
       - name: Setup build environment
         uses: ./.github/actions/setup-build-env
@@ -171,19 +118,18 @@ jobs:
           application-passphrase: ${{ secrets.APPLICATION_CERTIFICATE_PASSPHRASE }}
           release-certificate: ${{ secrets.RELEASE_CERTIFICATE_DATA }}
           release-passphrase: ${{ secrets.RELEASE_CERTIFICATE_PASSPHRASE }}
-          keychain-password: ${{ secrets.KEYCHAIN_PASSWORD }}
-
-      - name: Install Sentry CLI
-        run: brew install getsentry/tools/sentry-cli
 
       - name: Patch version from tag
         env:
-          VERSION: ${{ steps.release.outputs.tag }}
+          VERSION: ${{ github.ref_name }}
         run: |
           sed -E -i '' "s/MARKETING_VERSION = .*;/MARKETING_VERSION = ${VERSION};/g" "Pareto Security.xcodeproj/project.pbxproj"
 
       - name: Archive for distribution
         run: make archive-release-setapp
+
+      - name: Setup Sentry CLI
+        uses: ./.github/actions/setup-sentry-cli
 
       - name: Upload debug symbols
         env:
@@ -193,29 +139,20 @@ jobs:
       - name: Compress app for notarization
         run: ditto -c -k --keepParent "SetAppExport/Pareto Security.app" ParetoSecurity.app.zip
 
-      - name: Notarize release build
-        env:
-          NOTARIZATION_PASSWORD: ${{ secrets.NOTARIZATION_PASSWORD }}
-          NOTARIZATION_USERNAME: ${{ secrets.NOTARIZATION_USERNAME }}
+      # notarytool takes the zip, but the ticket is stapled onto the bundle so
+      # the archive uploaded below carries it.
+      - name: Notarize app
+        uses: ./.github/actions/notarize
+        with:
+          submit-path: ParetoSecurity.app.zip
+          staple-path: SetAppExport/Pareto Security.app
+          apple-id: ${{ secrets.NOTARIZATION_USERNAME }}
+          password: ${{ secrets.NOTARIZATION_PASSWORD }}
+
+      - name: Package stapled app for SetApp
         run: |
-          xcrun notarytool submit ParetoSecurity.app.zip \
-            --password "$NOTARIZATION_PASSWORD" \
-            --apple-id "$NOTARIZATION_USERNAME" \
-            --team-id PM784W7B8X \
-            --progress \
-            --wait
-
-      - name: Staple app
-        run: |
-          for i in {1..3}; do
-            xcrun stapler staple "SetAppExport/Pareto Security.app" && break || sleep 15
-          done
-
-      - name: Compress app for storage
-        run: ditto -c -k --keepParent "SetAppExport/Pareto Security.app" ParetoSecuritySetApp.app.zip
-
-      - name: Attach AppIcon for SetApp
-        run: make build-release-setapp
+          ditto -c -k --keepParent "SetAppExport/Pareto Security.app" ParetoSecuritySetApp.app.zip
+          make build-release-setapp
 
       - name: Upload artifact
         uses: actions/upload-artifact@v7
@@ -225,15 +162,10 @@ jobs:
           retention-days: 90
 
       - name: Publish build hashes
-        run: |
-          {
-            echo "## SetApp Release"
-            echo '```'
-            openssl dgst -md5 "SetAppExport/Pareto Security.app/Contents/MacOS/Pareto Security SetApp"
-            openssl dgst -sha1 "SetAppExport/Pareto Security.app/Contents/MacOS/Pareto Security SetApp"
-            openssl dgst -sha256 "SetAppExport/Pareto Security.app/Contents/MacOS/Pareto Security SetApp"
-            echo '```'
-          } >> "$GITHUB_STEP_SUMMARY"
+        uses: ./.github/actions/publish-hashes
+        with:
+          title: SetApp Release
+          binary: SetAppExport/Pareto Security.app/Contents/MacOS/Pareto Security SetApp
 
       - name: Cleanup keychain
         if: always()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,19 +52,32 @@ jobs:
       - name: Archive for distribution
         run: make archive-release
 
-      - name: Build release assets
+      - name: Build DMG
         run: |
           npm install --global create-dmg
           make dmg
-          ditto -c -k --keepParent "Export/Pareto Security.app" ParetoSecurity.app.zip
-          "Export/Pareto Security.app/Contents/MacOS/Pareto Security" -export > checks.json
 
+      # Notarizing the DMG covers the nested app, so the bundle can be
+      # stapled afterwards too.
       - name: Notarize DMG
         uses: ./.github/actions/notarize
         with:
           submit-path: ParetoSecurity.dmg
           apple-id: ${{ secrets.NOTARIZATION_USERNAME }}
           password: ${{ secrets.NOTARIZATION_PASSWORD }}
+
+      - name: Staple app
+        uses: ./.github/actions/notarize
+        with:
+          submit-path: Export/Pareto Security.app
+          staple-only: "true"
+
+      # Zip the app only after stapling so the in-app updater ships a
+      # bundle that passes Gatekeeper offline.
+      - name: Build update assets
+        run: |
+          ditto -c -k --keepParent "Export/Pareto Security.app" ParetoSecurity.app.zip
+          "Export/Pareto Security.app/Contents/MacOS/Pareto Security" -export > checks.json
 
       - name: Publish build hashes
         uses: ./.github/actions/publish-hashes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,6 +79,20 @@ jobs:
           ditto -c -k --keepParent "Export/Pareto Security.app" ParetoSecurity.app.zip
           "Export/Pareto Security.app/Contents/MacOS/Pareto Security" -export > checks.json
 
+      - name: Upload app artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: ParetoSecurity.app
+          path: ParetoSecurity.app.zip
+          retention-days: 90
+
+      - name: Upload DMG artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: ParetoSecurity.dmg
+          path: ParetoSecurity.dmg
+          retention-days: 90
+
       - name: Publish build hashes
         uses: ./.github/actions/publish-hashes
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,6 @@ jobs:
           development-passphrase: ${{ secrets.DEVELOPMENT_CERTIFICATE_PASSPHRASE }}
           application-certificate: ${{ secrets.APPLICATION_CERTIFICATE_DATA }}
           application-passphrase: ${{ secrets.APPLICATION_CERTIFICATE_PASSPHRASE }}
-          keychain-password: ${{ secrets.KEYCHAIN_PASSWORD }}
 
       - name: Run tests
         run: make test XCODEBUILD_FLAGS="$XCODEBUILD_FLAGS"
@@ -77,7 +76,6 @@ jobs:
           development-passphrase: ${{ secrets.DEVELOPMENT_CERTIFICATE_PASSPHRASE }}
           application-certificate: ${{ secrets.APPLICATION_CERTIFICATE_DATA }}
           application-passphrase: ${{ secrets.APPLICATION_CERTIFICATE_PASSPHRASE }}
-          keychain-password: ${{ secrets.KEYCHAIN_PASSWORD }}
 
       - name: Build debug archive
         run: set -o pipefail && make archive-debug 2>&1 | mint run xcbeautify
@@ -93,15 +91,10 @@ jobs:
           retention-days: 14
 
       - name: Publish build hashes
-        run: |
-          {
-            echo "## Debug Build"
-            echo '```'
-            openssl dgst -md5 "Export/Pareto Security.app/Contents/MacOS/Pareto Security"
-            openssl dgst -sha1 "Export/Pareto Security.app/Contents/MacOS/Pareto Security"
-            openssl dgst -sha256 "Export/Pareto Security.app/Contents/MacOS/Pareto Security"
-            echo '```'
-          } >> "$GITHUB_STEP_SUMMARY"
+        uses: ./.github/actions/publish-hashes
+        with:
+          title: Debug Build
+          binary: Export/Pareto Security.app/Contents/MacOS/Pareto Security
 
       - name: Cleanup keychain
         if: always()
@@ -133,7 +126,6 @@ jobs:
           development-passphrase: ${{ secrets.DEVELOPMENT_CERTIFICATE_PASSPHRASE }}
           application-certificate: ${{ secrets.APPLICATION_CERTIFICATE_DATA }}
           application-passphrase: ${{ secrets.APPLICATION_CERTIFICATE_PASSPHRASE }}
-          keychain-password: ${{ secrets.KEYCHAIN_PASSWORD }}
 
       - name: Build debug archive
         run: set -o pipefail && make archive-debug-setapp 2>&1 | mint run xcbeautify
@@ -149,15 +141,10 @@ jobs:
           retention-days: 14
 
       - name: Publish build hashes
-        run: |
-          {
-            echo "## SetApp Build"
-            echo '```'
-            openssl dgst -md5 "SetAppExport/Pareto Security.app/Contents/MacOS/Pareto Security SetApp"
-            openssl dgst -sha1 "SetAppExport/Pareto Security.app/Contents/MacOS/Pareto Security SetApp"
-            openssl dgst -sha256 "SetAppExport/Pareto Security.app/Contents/MacOS/Pareto Security SetApp"
-            echo '```'
-          } >> "$GITHUB_STEP_SUMMARY"
+        uses: ./.github/actions/publish-hashes
+        with:
+          title: SetApp Build
+          binary: SetAppExport/Pareto Security.app/Contents/MacOS/Pareto Security SetApp
 
       - name: Cleanup keychain
         if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,6 @@ jobs:
   build:
     name: Build Native
     runs-on: macos-latest
-    needs: test
     # Archiving and exporting require certificates, which forks never get.
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     timeout-minutes: 20
@@ -103,7 +102,6 @@ jobs:
   build-setapp:
     name: Build SetApp
     runs-on: macos-latest
-    needs: test
     # Archiving and exporting require certificates, which forks never get.
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     timeout-minutes: 20


### PR DESCRIPTION
## Summary
- Publish all release assets in a single atomic `action-gh-release` call, so a mid-job failure can no longer leave a half-published release
- Extract shared `notarize` and `publish-hashes` composite actions; stapling failures now fail the job instead of silently shipping an unstapled DMG
- `setup-signing`: single import step, throwaway keychain password via `uuidgen` (drops the `KEYCHAIN_PASSWORD` secret), `set-key-partition-list` for headless codesign, and a fail-fast verify step that prints cert subjects + expiry when no valid signing identity forms — turns failures like [run 32011051678](https://github.com/ParetoSecurity/pareto-mac/actions/runs/32011051678) into a readable ~20s error
- Drop duplicate app zip build and pre-staple artifact uploads; install sentry-cli via official installer; use `github.ref_name`; remove unused `deployments: write`

## Test plan
- [x] YAML validated for all workflows and composite actions
- [x] setup-signing and notarize scripts executed locally (throwaway .p12, stubbed `xcrun`) covering success and failure paths
- [ ] Real validation on the next tag push